### PR TITLE
feat(client): Added relay support in the client

### DIFF
--- a/apps/client/src/hooks/useEvent.ts
+++ b/apps/client/src/hooks/useEvent.ts
@@ -40,6 +40,12 @@ const GET_EVENT = gql`
         length
         climb
         resultListMode
+        course {
+          id
+          name
+          length
+          climb
+        }
       }
       user {
         id

--- a/apps/client/src/i18n/locales/cs/translation.json
+++ b/apps/client/src/i18n/locales/cs/translation.json
@@ -672,7 +672,15 @@
           "Overall": "Celkově",
           "Leg": "Úsek {{number}}",
           "Start": "Start",
-          "Time": "Čas"
+          "Time": "Čas",
+          "Diff": "Ztráta",
+          "AutoFollow": "Auto",
+          "Name": "Jméno",
+          "Club": "Klub",
+          "LegHeader": "Úsek",
+          "LegLoss": "+Úsek",
+          "Cumul": "Celk.",
+          "ErrorLoading": "Chyba při načítání výsledků"
         },
         "Ranking": {
           "Counts": "Započítá se do rankingu",

--- a/apps/client/src/i18n/locales/cs/translation.json
+++ b/apps/client/src/i18n/locales/cs/translation.json
@@ -668,6 +668,12 @@
         "LoadingClubs": "Načítám kluby",
         "LoadingClubResults": "Načítám klubové výsledky",
         "ErrorLoadingClubResults": "Chyba při načítání klubových výsledků: {{message}}",
+        "Relay": {
+          "Overall": "Celkově",
+          "Leg": "Úsek {{number}}",
+          "Start": "Start",
+          "Time": "Čas"
+        },
         "Ranking": {
           "Counts": "Započítá se do rankingu",
           "DoesNotCount": "Nezapočítá se do rankingu",

--- a/apps/client/src/i18n/locales/de/translation.json
+++ b/apps/client/src/i18n/locales/de/translation.json
@@ -714,7 +714,15 @@
           "Overall": "Gesamt",
           "Leg": "Abschnitt {{number}}",
           "Start": "Start",
-          "Time": "Zeit"
+          "Time": "Zeit",
+          "Diff": "Rückstand",
+          "AutoFollow": "Auto",
+          "Name": "Name",
+          "Club": "Verein",
+          "LegHeader": "Abschn.",
+          "LegLoss": "+Abschn.",
+          "Cumul": "Kumulativ",
+          "ErrorLoading": "Fehler beim Laden der Ergebnisse"
         }
       },
       "Settings": {

--- a/apps/client/src/i18n/locales/de/translation.json
+++ b/apps/client/src/i18n/locales/de/translation.json
@@ -709,6 +709,14 @@
         "NoClubs": "Keine Klubs gefunden",
         "Cancel": "Abbrechen"
       },
+      "Results": {
+        "Relay": {
+          "Overall": "Gesamt",
+          "Leg": "Abschnitt {{number}}",
+          "Start": "Start",
+          "Time": "Zeit"
+        }
+      },
       "Settings": {
         "Loading": "Loading event settings",
         "Tabs": {

--- a/apps/client/src/i18n/locales/en/translation.json
+++ b/apps/client/src/i18n/locales/en/translation.json
@@ -668,6 +668,12 @@
         "LoadingClubs": "Loading clubs",
         "LoadingClubResults": "Loading club results",
         "ErrorLoadingClubResults": "Error loading club results: {{message}}",
+        "Relay": {
+          "Overall": "Overall",
+          "Leg": "Leg {{number}}",
+          "Start": "Start",
+          "Time": "Time"
+        },
         "Ranking": {
           "Counts": "Counts towards ranking",
           "DoesNotCount": "Does not count towards ranking",

--- a/apps/client/src/i18n/locales/en/translation.json
+++ b/apps/client/src/i18n/locales/en/translation.json
@@ -672,7 +672,15 @@
           "Overall": "Overall",
           "Leg": "Leg {{number}}",
           "Start": "Start",
-          "Time": "Time"
+          "Time": "Time",
+          "Diff": "Diff",
+          "AutoFollow": "Auto-follow",
+          "Name": "Name",
+          "Club": "Club",
+          "LegHeader": "Leg",
+          "LegLoss": "+Leg",
+          "Cumul": "Cumul.",
+          "ErrorLoading": "Error loading results"
         },
         "Ranking": {
           "Counts": "Counts towards ranking",

--- a/apps/client/src/i18n/locales/es/translation.json
+++ b/apps/client/src/i18n/locales/es/translation.json
@@ -668,6 +668,12 @@
         "LoadingClubs": "Cargando clubes",
         "LoadingClubResults": "Cargando resultados por club",
         "ErrorLoadingClubResults": "Error al cargar resultados por club: {{message}}",
+        "Relay": {
+          "Overall": "General",
+          "Leg": "Tramo {{number}}",
+          "Start": "Salida",
+          "Time": "Tiempo"
+        },
         "Ranking": {
           "Counts": "Cuenta para el ranking",
           "DoesNotCount": "No cuenta para el ranking",

--- a/apps/client/src/i18n/locales/es/translation.json
+++ b/apps/client/src/i18n/locales/es/translation.json
@@ -672,7 +672,15 @@
           "Overall": "General",
           "Leg": "Tramo {{number}}",
           "Start": "Salida",
-          "Time": "Tiempo"
+          "Time": "Tiempo",
+          "Diff": "Diferencia",
+          "AutoFollow": "Auto",
+          "Name": "Nombre",
+          "Club": "Club",
+          "LegHeader": "Tramo",
+          "LegLoss": "+Tramo",
+          "Cumul": "Acum.",
+          "ErrorLoading": "Error al cargar los resultados"
         },
         "Ranking": {
           "Counts": "Cuenta para el ranking",

--- a/apps/client/src/i18n/locales/fr/translation.json
+++ b/apps/client/src/i18n/locales/fr/translation.json
@@ -60,7 +60,15 @@
           "Overall": "Général",
           "Leg": "Relais {{number}}",
           "Start": "Départ",
-          "Time": "Temps"
+          "Time": "Temps",
+          "Diff": "Écart",
+          "AutoFollow": "Auto",
+          "Name": "Nom",
+          "Club": "Club",
+          "LegHeader": "Relais",
+          "LegLoss": "+Relais",
+          "Cumul": "Cumul.",
+          "ErrorLoading": "Erreur lors du chargement des résultats"
         }
       },
       "Settings": {

--- a/apps/client/src/i18n/locales/fr/translation.json
+++ b/apps/client/src/i18n/locales/fr/translation.json
@@ -55,6 +55,14 @@
         "NoClubs": "Aucun club trouvé",
         "Cancel": "Annuler"
       },
+      "Results": {
+        "Relay": {
+          "Overall": "Général",
+          "Leg": "Relais {{number}}",
+          "Start": "Départ",
+          "Time": "Temps"
+        }
+      },
       "Settings": {
         "Loading": "Loading event settings",
         "Tabs": {

--- a/apps/client/src/i18n/locales/sv/translation.json
+++ b/apps/client/src/i18n/locales/sv/translation.json
@@ -672,7 +672,15 @@
           "Overall": "Totalt",
           "Leg": "Sträcka {{number}}",
           "Start": "Start",
-          "Time": "Tid"
+          "Time": "Tid",
+          "Diff": "Diff",
+          "AutoFollow": "Auto",
+          "Name": "Namn",
+          "Club": "Klubb",
+          "LegHeader": "Sträcka",
+          "LegLoss": "+Sträcka",
+          "Cumul": "Kumulat.",
+          "ErrorLoading": "Fel vid inläsning av resultat"
         },
         "Ranking": {
           "Counts": "Räknas till rankingen",

--- a/apps/client/src/i18n/locales/sv/translation.json
+++ b/apps/client/src/i18n/locales/sv/translation.json
@@ -668,6 +668,12 @@
         "LoadingClubs": "Läser in klubbar",
         "LoadingClubResults": "Läser in klubbresultat",
         "ErrorLoadingClubResults": "Fel vid inläsning av klubbresultat: {{message}}",
+        "Relay": {
+          "Overall": "Totalt",
+          "Leg": "Sträcka {{number}}",
+          "Start": "Start",
+          "Time": "Tid"
+        },
         "Ranking": {
           "Counts": "Räknas till rankingen",
           "DoesNotCount": "Räknas inte till rankingen",

--- a/apps/client/src/pages/Event/EventResultsView.tsx
+++ b/apps/client/src/pages/Event/EventResultsView.tsx
@@ -140,6 +140,7 @@ const COMPETITORS_BY_CLASS_UPDATED = gql`
   }
 `;
 
+
 const ORGANISATIONS = gql`
   query OrganisationNames($eventId: String!) {
     organisationNames(eventId: $eventId) {
@@ -194,6 +195,7 @@ const COMPETITORS_BY_ORGANISATION = gql`
 interface CompetitorsByClassUpdatedResponse {
   competitorsByClassUpdated: Competitor[];
 }
+
 
 interface EventResultsViewProps {
   t: TFunction;
@@ -1121,40 +1123,8 @@ const ClubResultsView = ({
 
     // For non-OK status competitors, return appropriate position emoji
     if (competitor.status !== 'OK') {
-      let positionWithEmoji: string;
-
-      switch (competitor.status) {
-        case 'Active':
-          positionWithEmoji = '🏃';
-          break;
-        case 'DidNotFinish':
-          positionWithEmoji = '🏳️';
-          break;
-        case 'DidNotStart':
-          positionWithEmoji = '🚷';
-          break;
-        case 'Disqualified':
-          positionWithEmoji = '🟥';
-          break;
-        case 'Finished':
-          positionWithEmoji = '🏁';
-          break;
-        case 'Inactive':
-          positionWithEmoji = '🛏️';
-          break;
-        case 'MissingPunch':
-          positionWithEmoji = '🙈';
-          break;
-        case 'NotCompeting':
-          positionWithEmoji = '🦄';
-          break;
-        case 'OverTime':
-          positionWithEmoji = '⌛';
-          break;
-        default:
-          positionWithEmoji = '❓';
-      }
-
+      const positionWithEmoji =
+        getStatusDisplay(competitor.status).emoji;
       return { position: positionWithEmoji, loss: undefined };
     }
 
@@ -1386,8 +1356,7 @@ const ClubResultsView = ({
     return 'text-gray-600 dark:text-gray-400';
   };
 
-  // Get status display text
-  const getStatusDisplay = (status: string) => {
+  const getStatusLabel = (status: string) => {
     const statusMap: Record<string, string> = {
       OK: 'OK',
       Active: 'Active',
@@ -1573,7 +1542,7 @@ const ClubResultsView = ({
                               <span
                                 className={`text-xs font-medium ${getStatusColor(runner.status)}`}
                               >
-                                {getStatusDisplay(runner.status)}
+                                {getStatusLabel(runner.status)}
                               </span>
                             </TableCell>
                           </TableRow>
@@ -1793,29 +1762,25 @@ const computeRelayOverall = (
   return results;
 };
 
-const relayStatusEmoji: Record<string, string> = {
-  Active: '🏃',
-  DidNotFinish: '🏳️',
-  DidNotStart: '🚷',
-  Disqualified: '🟥',
-  Finished: '🏁',
-  Inactive: '🛏️',
-  MissingPunch: '🙈',
-  NotCompeting: '🦄',
-  OverTime: '⌛',
+const COMPETITOR_STATUS_DISPLAY: Record<
+  string,
+  { emoji: string; tooltip: string }
+> = {
+  Active: { emoji: '🏃', tooltip: 'Giving it their all right now' },
+  DidNotFinish: { emoji: '🏳️', tooltip: 'Did Not Finish' },
+  DidNotStart: { emoji: '🚷', tooltip: 'Did Not Start' },
+  Disqualified: { emoji: '🟥', tooltip: 'Disqualified' },
+  Finished: { emoji: '🏁', tooltip: 'Waiting for readout' },
+  Inactive: { emoji: '🛏️', tooltip: 'Waiting for start time' },
+  MissingPunch: { emoji: '🙈', tooltip: 'Missing Punch' },
+  NotCompeting: { emoji: '🦄', tooltip: 'Not competing' },
+  OverTime: { emoji: '⌛', tooltip: 'Over Time' },
 };
-
-const relayStatusTooltip: Record<string, string> = {
-  Active: 'Giving it their all right now',
-  DidNotFinish: 'Did Not Finish',
-  DidNotStart: 'Did Not Start',
-  Disqualified: 'Disqualified',
-  Finished: 'Waiting for readout',
-  Inactive: 'Waiting for start time',
-  MissingPunch: 'Missing Punch',
-  NotCompeting: 'Not competing',
-  OverTime: 'Over Time',
-};
+const getStatusDisplay = (status: string | null | undefined) =>
+  COMPETITOR_STATUS_DISPLAY[status ?? ''] ?? {
+    emoji: '❓',
+    tooltip: 'Unknown status',
+  };
 
 const PositionChange: React.FC<{ change: number }> = ({ change }) => {
   if (change === 0) {
@@ -1839,7 +1804,10 @@ const PositionChange: React.FC<{ change: number }> = ({ change }) => {
   );
 };
 
-const RelayOverallView: React.FC<{ teams: TeamResult[] }> = ({ teams }) => {
+const RelayOverallView: React.FC<{ teams: TeamResult[]; t: TFunction }> = ({
+  teams,
+  t,
+}) => {
   if (teams.length === 0) return null;
 
   return (
@@ -1849,19 +1817,23 @@ const RelayOverallView: React.FC<{ teams: TeamResult[] }> = ({ teams }) => {
           <TableHeader>
             <TableRow className="bg-muted/50">
               <TableHead className="h-8 px-2 text-xs">#</TableHead>
-              <TableHead className="h-8 px-2 text-xs">Name</TableHead>
+              <TableHead className="h-8 px-2 text-xs">
+                {t('Pages.Event.Results.Relay.Name')}
+              </TableHead>
               <TableHead className="h-8 px-2 text-xs hidden lg:table-cell">
-                Club
+                {t('Pages.Event.Results.Relay.Club')}
               </TableHead>
-              <TableHead className="h-8 px-2 text-right text-xs">Leg</TableHead>
+              <TableHead className="h-8 px-2 text-right text-xs">
+                {t('Pages.Event.Results.Relay.LegHeader')}
+              </TableHead>
               <TableHead className="h-8 px-2 text-right text-xs hidden sm:table-cell">
-                +Leg
+                {t('Pages.Event.Results.Relay.LegLoss')}
               </TableHead>
               <TableHead className="h-8 px-2 text-right text-xs">
-                Time
+                {t('Pages.Event.Results.Relay.Time')}
               </TableHead>
               <TableHead className="h-8 px-2 text-right text-xs">
-                +Time
+                {t('Pages.Event.Results.Relay.Diff')}
               </TableHead>
             </TableRow>
           </TableHeader>
@@ -1877,12 +1849,7 @@ const RelayOverallView: React.FC<{ teams: TeamResult[] }> = ({ teams }) => {
                     {team.finalRank != null ? `${team.finalRank}.` : '–'}
                   </TableCell>
                   <TableCell className="px-2 py-1.5 text-sm font-bold">
-                    <div className="flex flex-col">
-                      <span>{team.teamName}</span>
-                      <span className="text-xs font-normal text-muted-foreground lg:hidden">
-                        {team.club}
-                      </span>
-                    </div>
+                    {team.teamName}
                   </TableCell>
                   <TableCell className="px-2 py-1.5 text-xs text-muted-foreground hidden lg:table-cell">
                     {team.club}
@@ -1909,10 +1876,7 @@ const RelayOverallView: React.FC<{ teams: TeamResult[] }> = ({ teams }) => {
                   >
                     <TableCell />
                     <TableCell className="px-2 py-0.5 text-xs">
-                      <span className="text-muted-foreground mr-1">
-                        {leg.runner.registration}
-                      </span>
-                      {leg.runner.firstname} {leg.runner.lastname}
+                      <CompetitorName competitor={leg.runner} />
                     </TableCell>
                     <TableCell className="hidden lg:table-cell" />
                     <TableCell className="px-2 py-0.5 text-right font-mono text-xs">
@@ -1928,12 +1892,9 @@ const RelayOverallView: React.FC<{ teams: TeamResult[] }> = ({ teams }) => {
                       ) : (
                         <span
                           className="text-muted-foreground cursor-help"
-                          title={
-                            relayStatusTooltip[leg.runner.status] ??
-                            leg.runner.status
-                          }
+                          title={getStatusDisplay(leg.runner.status).tooltip}
                         >
-                          {relayStatusEmoji[leg.runner.status] ?? '–'}
+                          {getStatusDisplay(leg.runner.status).emoji}
                         </span>
                       )}
                     </TableCell>
@@ -2055,18 +2016,6 @@ const processRelayLegCompetitors = (
     position++;
   }
 
-  const statusEmojis: Record<string, [string, string]> = {
-    Active: ['🏃', 'Giving it their all right now'],
-    DidNotFinish: ['🏳️', 'Did Not Finish'],
-    DidNotStart: ['🚷', 'Did not start'],
-    Disqualified: ['🟥', 'Disqualified'],
-    Finished: ['🏁', 'Waiting for readout'],
-    Inactive: ['🛏️', 'Waiting for start time'],
-    MissingPunch: ['🙈', 'Missing Punch'],
-    NotCompeting: ['🦄', 'Not competing'],
-    OverTime: ['⌛', 'Over Time'],
-  };
-
   return withCumulative.map(c => {
     const pos = posMap.get(c.id);
     if (pos !== undefined) {
@@ -2078,14 +2027,19 @@ const processRelayLegCompetitors = (
       if (loss !== undefined && loss > 0) result.loss = loss;
       return result;
     }
-    const [emoji, tooltip] = statusEmojis[c.status] ?? ['❓', 'Unknown status'];
+    const display = getStatusDisplay(c.status);
     return {
       ...c,
-      position: emoji,
-      positionTooltip: tooltip,
+      position: display.emoji,
+      positionTooltip: display.tooltip,
     } as RelayLegCompetitor;
   });
 };
+
+const hasRelayResultSignal = (competitor: Competitor): boolean =>
+  competitor.time != null ||
+  competitor.finishTime != null ||
+  competitor.status === 'Active';
 
 interface RelayResultsViewProps {
   t: TFunction;
@@ -2102,6 +2056,8 @@ const RelayResultsView = ({
 }: RelayResultsViewProps) => {
   const [selectedTab, setSelectedTab] = useState<'overall' | number>('overall');
   const [currentTime, setCurrentTime] = useState<number>(Date.now());
+  const [autoFollowEnabled, setAutoFollowEnabled] = useState(false);
+  const previousClassIdRef = useRef<number | undefined>(undefined);
   const navigate = useNavigate();
 
   const currentClass = event.classes?.find(cls => cls.name === selectedClass);
@@ -2114,6 +2070,8 @@ const RelayResultsView = ({
     );
 
   useEffect(() => {
+    if (previousClassIdRef.current === selectedClassId) return;
+    previousClassIdRef.current = selectedClassId;
     setSelectedTab('overall');
   }, [selectedClassId]);
 
@@ -2127,7 +2085,7 @@ const RelayResultsView = ({
   const allCompetitors = data?.competitorsByClassUpdated ?? [];
 
   const maxLeg = useMemo(
-    () => allCompetitors.reduce((max, c) => Math.max(max, c.leg ?? 1), 0),
+    () => allCompetitors.reduce((max, c) => Math.max(max, c.leg ?? 0), 0),
     [allCompetitors]
   );
 
@@ -2156,9 +2114,18 @@ const RelayResultsView = ({
 
   const processedLegCompetitors = useMemo(() => {
     if (selectedLeg == null) return [];
-    const legComps = allCompetitors.filter(c => (c.leg ?? 1) === selectedLeg);
+    const legComps = allCompetitors.filter(c => c.leg === selectedLeg);
     return processRelayLegCompetitors(legComps, selectedLeg, teamTimeMap);
   }, [allCompetitors, selectedLeg, teamTimeMap]);
+
+  const mobileClubWidthReference = useMemo(
+    () =>
+      processedLegCompetitors.reduce((longest, competitor) => {
+        const name = getMobileCompetitorName(competitor);
+        return name.length > longest.length ? name : longest;
+      }, ''),
+    [processedLegCompetitors]
+  );
 
   const legPositionChangeMap = useMemo(() => {
     if (selectedLeg == null || selectedLeg <= 1)
@@ -2177,6 +2144,29 @@ const RelayResultsView = ({
     selectedTab === 'overall'
       ? teamResults.length > 0
       : processedLegCompetitors.length > 0;
+
+  const autoFollowTargetLeg = useMemo(() => {
+    if (maxLeg === 0) return null;
+    const highestLegWithResults = allCompetitors.reduce(
+      (highest, competitor) => {
+        const leg = competitor.leg ?? 0;
+        return hasRelayResultSignal(competitor) && leg > highest
+          ? leg
+          : highest;
+      },
+      0
+    );
+    return highestLegWithResults > 0
+      ? Math.min(maxLeg, highestLegWithResults)
+      : null;
+  }, [allCompetitors, maxLeg]);
+
+  useEffect(() => {
+    if (!autoFollowEnabled || autoFollowTargetLeg == null) return;
+    if (selectedTab !== autoFollowTargetLeg) {
+      setSelectedTab(autoFollowTargetLeg);
+    }
+  }, [autoFollowEnabled, autoFollowTargetLeg, selectedTab]);
 
   const showFirstLegStartTimes = selectedLeg === 1;
 
@@ -2219,6 +2209,19 @@ const RelayResultsView = ({
     setSelectedClass(cls.name);
   };
 
+  const handleManualTabChange = (tab: 'overall' | number) => {
+    setAutoFollowEnabled(false);
+    setSelectedTab(tab);
+  };
+
+  const handleAutoFollowToggle = () => {
+    const nextEnabled = !autoFollowEnabled;
+    setAutoFollowEnabled(nextEnabled);
+    if (nextEnabled && autoFollowTargetLeg != null) {
+      setSelectedTab(autoFollowTargetLeg);
+    }
+  };
+
   return (
     <div className="flex flex-col h-full">
       <div className="sticky top-0 z-10 bg-background border-b border-border pb-2 mb-2">
@@ -2234,7 +2237,7 @@ const RelayResultsView = ({
                   className={
                     courseLength > 0 ? 'h-auto py-0.5 px-2' : 'h-7 px-2'
                   }
-                  onClick={() => setSelectedTab('overall')}
+                  onClick={() => handleManualTabChange('overall')}
                 >
                   <span className="flex flex-col items-center leading-none gap-0.5">
                     <span className="text-xs font-medium">
@@ -2259,7 +2262,7 @@ const RelayResultsView = ({
                   variant={selectedTab === leg ? 'default' : 'ghost'}
                   size="sm"
                   className={courseLength ? 'h-auto py-0.5 px-2' : 'h-7 px-2'}
-                  onClick={() => setSelectedTab(leg)}
+                  onClick={() => handleManualTabChange(leg)}
                 >
                   <span className="flex flex-col items-center leading-none gap-0.5">
                     <span className="text-xs font-medium">
@@ -2275,6 +2278,18 @@ const RelayResultsView = ({
                 </Button>
               );
             })}
+            <Button
+              variant={autoFollowEnabled ? 'default' : 'ghost'}
+              size="sm"
+              className="h-7 px-2 gap-1"
+              disabled={maxLeg === 0}
+              onClick={handleAutoFollowToggle}
+            >
+              <Radio className="w-3 h-3" />
+              <span className="text-xs font-medium">
+                {t('Pages.Event.Results.Relay.AutoFollow')}
+              </span>
+            </Button>
           </div>
           {event.classes && currentClass && (
             <EventCategorySwitcher
@@ -2298,7 +2313,7 @@ const RelayResultsView = ({
         <Alert
           severity="error"
           variant="outlined"
-          title="Error loading results"
+          title={t('Pages.Event.Results.Relay.ErrorLoading')}
         >
           {error.message}
         </Alert>
@@ -2316,7 +2331,9 @@ const RelayResultsView = ({
         </Alert>
       )}
 
-      {selectedTab === 'overall' && <RelayOverallView teams={teamResults} />}
+      {selectedTab === 'overall' && (
+        <RelayOverallView teams={teamResults} t={t} />
+      )}
 
       {typeof selectedTab === 'number' &&
         processedLegCompetitors.length > 0 && (
@@ -2326,9 +2343,11 @@ const RelayResultsView = ({
                 <TableHeader>
                   <TableRow className="bg-muted/50">
                     <TableHead className="h-8 px-2 text-xs">#</TableHead>
-                    <TableHead className="h-8 px-2 text-xs">Name</TableHead>
+                    <TableHead className="h-8 px-2 text-xs">
+                      {t('Pages.Event.Results.Relay.Name')}
+                    </TableHead>
                     <TableHead className="h-8 px-2 text-xs hidden lg:table-cell">
-                      Club
+                      {t('Pages.Event.Results.Relay.Club')}
                     </TableHead>
                     {showFirstLegStartTimes && (
                       <TableHead className="h-8 px-2 text-xs text-right hidden md:table-cell">
@@ -2340,11 +2359,11 @@ const RelayResultsView = ({
                     </TableHead>
                     {selectedLeg != null && selectedLeg > 1 && (
                       <TableHead className="h-8 px-2 text-right text-xs hidden sm:table-cell">
-                        Cumul.
+                        {t('Pages.Event.Results.Relay.Cumul')}
                       </TableHead>
                     )}
                     <TableHead className="h-8 px-2 text-right text-xs">
-                      Diff
+                      {t('Pages.Event.Results.Relay.Diff')}
                     </TableHead>
                   </TableRow>
                 </TableHeader>
@@ -2389,9 +2408,11 @@ const RelayResultsView = ({
                         <TableCell className="px-2 py-1 text-sm font-medium">
                           <div className="flex flex-col">
                             <CompetitorName competitor={competitor} />
-                            <span className="mt-0.5 block truncate text-left text-xs text-muted-foreground lg:hidden">
-                              {competitor.organisation}
-                            </span>
+                            <MobileClubName
+                              clubName={competitor.organisation}
+                              referenceText={mobileClubWidthReference}
+                              className="mt-0.5 block truncate text-left text-xs text-muted-foreground lg:hidden"
+                            />
                           </div>
                         </TableCell>
                         <TableCell className="px-2 py-1 text-xs text-muted-foreground hidden lg:table-cell">
@@ -2548,55 +2569,12 @@ const calculatePositions = (runners: Competitor[]): ProcessedCompetitor[] => {
     }
 
     // Non-finished běžci
-    let positionWithEmoji: string;
-    let positionTooltip: string;
-
-    switch (runner.status) {
-      case 'Active':
-        positionWithEmoji = '🏃';
-        positionTooltip = 'Giving it their all right now';
-        break;
-      case 'DidNotFinish':
-        positionWithEmoji = '🏳️';
-        positionTooltip = 'Did Not Finish';
-        break;
-      case 'DidNotStart':
-        positionWithEmoji = '🚷';
-        positionTooltip = 'Did not start';
-        break;
-      case 'Disqualified':
-        positionWithEmoji = '🟥';
-        positionTooltip = 'Disqualified';
-        break;
-      case 'Finished':
-        positionWithEmoji = '🏁';
-        positionTooltip = 'Waiting for readout';
-        break;
-      case 'Inactive':
-        positionWithEmoji = '🛏️';
-        positionTooltip = 'Waiting for start time';
-        break;
-      case 'MissingPunch':
-        positionWithEmoji = '🙈';
-        positionTooltip = 'Missing Punch';
-        break;
-      case 'NotCompeting':
-        positionWithEmoji = '🦄';
-        positionTooltip = 'Not competing';
-        break;
-      case 'OverTime':
-        positionWithEmoji = '⌛';
-        positionTooltip = 'Over Time';
-        break;
-      default:
-        positionWithEmoji = '❓';
-        positionTooltip = 'Unknown status';
-    }
+    const statusDisplay = getStatusDisplay(runner.status);
 
     return {
       ...runner,
-      position: positionWithEmoji,
-      positionTooltip,
+      position: statusDisplay.emoji,
+      positionTooltip: statusDisplay.tooltip,
     };
   });
 };

--- a/apps/client/src/pages/Event/EventResultsView.tsx
+++ b/apps/client/src/pages/Event/EventResultsView.tsx
@@ -23,7 +23,13 @@ import { useNavigate } from '@tanstack/react-router';
 import { TFunction } from 'i18next';
 import { ChevronDown, Loader2, Radio, Trophy, Users } from 'lucide-react';
 import { motion } from 'motion/react';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { Badge, Button, CountryFlag, Tooltip } from '../../components/atoms';
 import { Alert } from '../../components/organisms';
@@ -58,6 +64,50 @@ const getClubSheetMaxHeight = () =>
 const mobileResultsTableClassName =
   'overflow-x-auto [&_table]:text-sm [&_th]:h-7 sm:[&_th]:h-8 [&_th]:px-1.5 sm:[&_th]:px-2 [&_th]:text-xs [&_td]:px-1.5 sm:[&_td]:px-2 [&_td]:py-0.5 sm:[&_td]:py-1 [&_td]:text-sm';
 
+const getActiveTimeState = (
+  startTime: string | undefined,
+  currentTime: number
+): { value: string; className: string } => {
+  if (!startTime) {
+    return { value: '-', className: 'text-muted-foreground' };
+  }
+
+  try {
+    const start = new Date(startTime).getTime();
+
+    if (Number.isNaN(start)) {
+      return { value: '-', className: 'text-muted-foreground' };
+    }
+
+    const elapsedSeconds = Math.floor((currentTime - start) / 1000);
+
+    if (elapsedSeconds < 0) {
+      const secondsUntilStart = Math.abs(elapsedSeconds);
+      const className =
+        secondsUntilStart <= 5
+          ? 'animate-pulse text-orange-600 dark:text-orange-400'
+          : 'text-muted-foreground';
+
+      return {
+        value: `- ${formatSecondsToTime(secondsUntilStart)}`,
+        className,
+      };
+    }
+
+    const className =
+      elapsedSeconds <= 5
+        ? 'animate-pulse text-green-600 dark:text-green-400'
+        : 'text-muted-foreground';
+
+    return {
+      value: formatSecondsToTime(elapsedSeconds),
+      className,
+    };
+  } catch {
+    return { value: '-', className: 'text-muted-foreground' };
+  }
+};
+
 // GraphQL queries and subscriptions
 const COMPETITORS_BY_CLASS_UPDATED = gql`
   subscription CompetitorsByClassUpdated($classId: Int!) {
@@ -80,6 +130,12 @@ const COMPETITORS_BY_CLASS_UPDATED = gql`
       status
       lateStart
       note
+      leg
+      teamId
+      team {
+        id
+        name
+      }
     }
   }
 `;
@@ -134,34 +190,9 @@ const COMPETITORS_BY_ORGANISATION = gql`
   }
 `;
 
-const RELAY_RESULTS_UPDATED = gql`
-  subscription RelayResultsUpdated($eventId: String!, $classId: Int!) {
-    relayResultsUpdated(eventId: $eventId, classId: $classId) {
-      id
-      rank
-      teamName
-      club
-      countryCode
-      totalTime
-      behind
-      legs {
-        legNumber
-        runnerName
-        time
-        rank
-        status
-      }
-    }
-  }
-`;
-
 // Type definitions
 interface CompetitorsByClassUpdatedResponse {
   competitorsByClassUpdated: Competitor[];
-}
-
-interface RelayResultsUpdatedResponse {
-  relayResultsUpdated: RelayResult[];
 }
 
 interface EventResultsViewProps {
@@ -191,6 +222,9 @@ interface Competitor {
   status: string;
   lateStart?: boolean;
   note?: string;
+  leg?: number;
+  teamId?: number;
+  team?: { id: number; name: string } | null;
 }
 
 interface ProcessedCompetitor extends Competitor {
@@ -236,23 +270,6 @@ interface ProcessedClubResult {
   runners: ClubRunner[];
 }
 
-interface RelayResult {
-  id: string;
-  rank: number;
-  teamName: string;
-  club: string;
-  countryCode: string;
-  totalTime: string;
-  behind?: string;
-  legs: {
-    legNumber: number;
-    runnerName: string;
-    time: string;
-    rank: number;
-    status: 'finished' | 'running' | 'not_started';
-  }[];
-}
-
 export const EventResultsView = ({ t, event }: EventResultsViewProps) => {
   const isRelay = event.relay;
   const navigate = useNavigate();
@@ -278,9 +295,13 @@ export const EventResultsView = ({ t, event }: EventResultsViewProps) => {
   const { t: tLocal } = useTranslation();
   const [selectedClubId, setSelectedClubId] = useState<number | null>(null);
   const [isClubSheetOpen, setIsClubSheetOpen] = useState(false);
-  const [clubSheetHeight, setClubSheetHeight] = useState(getClubSheetDefaultHeight);
+  const [clubSheetHeight, setClubSheetHeight] = useState(
+    getClubSheetDefaultHeight
+  );
   const [isClubSheetDragging, setIsClubSheetDragging] = useState(false);
-  const clubDragState = useRef<{ startY: number; startHeight: number } | null>(null);
+  const clubDragState = useRef<{ startY: number; startHeight: number } | null>(
+    null
+  );
 
   useEffect(() => {
     if (isClubSheetOpen) setClubSheetHeight(getClubSheetDefaultHeight());
@@ -290,37 +311,46 @@ export const EventResultsView = ({ t, event }: EventResultsViewProps) => {
     (e: React.PointerEvent<HTMLElement>) => {
       e.preventDefault();
       e.currentTarget.setPointerCapture(e.pointerId);
-      clubDragState.current = { startY: e.clientY, startHeight: clubSheetHeight };
+      clubDragState.current = {
+        startY: e.clientY,
+        startHeight: clubSheetHeight,
+      };
       setIsClubSheetDragging(true);
     },
-    [clubSheetHeight],
+    [clubSheetHeight]
   );
 
-  const handleClubDragMove = useCallback((e: React.PointerEvent<HTMLElement>) => {
-    if (!clubDragState.current) return;
-    const delta = clubDragState.current.startY - e.clientY;
-    const next = clubDragState.current.startHeight + delta;
-    if (next < CLUB_SHEET_MIN_HEIGHT - CLUB_SHEET_DISMISS_THRESHOLD) {
-      clubDragState.current = null;
+  const handleClubDragMove = useCallback(
+    (e: React.PointerEvent<HTMLElement>) => {
+      if (!clubDragState.current) return;
+      const delta = clubDragState.current.startY - e.clientY;
+      const next = clubDragState.current.startHeight + delta;
+      if (next < CLUB_SHEET_MIN_HEIGHT - CLUB_SHEET_DISMISS_THRESHOLD) {
+        clubDragState.current = null;
+        if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+          e.currentTarget.releasePointerCapture(e.pointerId);
+        }
+        setIsClubSheetDragging(false);
+        setIsClubSheetOpen(false);
+        return;
+      }
+      setClubSheetHeight(
+        Math.min(getClubSheetMaxHeight(), Math.max(CLUB_SHEET_MIN_HEIGHT, next))
+      );
+    },
+    []
+  );
+
+  const handleClubDragEnd = useCallback(
+    (e: React.PointerEvent<HTMLElement>) => {
       if (e.currentTarget.hasPointerCapture(e.pointerId)) {
         e.currentTarget.releasePointerCapture(e.pointerId);
       }
+      clubDragState.current = null;
       setIsClubSheetDragging(false);
-      setIsClubSheetOpen(false);
-      return;
-    }
-    setClubSheetHeight(
-      Math.min(getClubSheetMaxHeight(), Math.max(CLUB_SHEET_MIN_HEIGHT, next)),
-    );
-  }, []);
-
-  const handleClubDragEnd = useCallback((e: React.PointerEvent<HTMLElement>) => {
-    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
-      e.currentTarget.releasePointerCapture(e.pointerId);
-    }
-    clubDragState.current = null;
-    setIsClubSheetDragging(false);
-  }, []);
+    },
+    []
+  );
   const [categoryCompetitorsCount, setCategoryCompetitorsCount] =
     useState<number>(0);
   const [isCategoryLoading, setIsCategoryLoading] = useState(false);
@@ -372,10 +402,10 @@ export const EventResultsView = ({ t, event }: EventResultsViewProps) => {
       <>
         <WinnerNotification eventId={event.id} />
         <RelayResultsView
+          t={t}
           event={event}
           selectedClass={selectedClass}
           setSelectedClass={setSelectedClass}
-          availableClasses={event.classes?.map(cls => cls.name) || []}
         />
       </>
     );
@@ -467,7 +497,9 @@ export const EventResultsView = ({ t, event }: EventResultsViewProps) => {
                 style={{
                   height: clubSheetHeight,
                   maxHeight: '90vh',
-                  transition: isClubSheetDragging ? 'none' : 'height 200ms ease',
+                  transition: isClubSheetDragging
+                    ? 'none'
+                    : 'height 200ms ease',
                 }}
               >
                 <SheetHeader className="text-left shrink-0 px-6 pt-2">
@@ -481,7 +513,7 @@ export const EventResultsView = ({ t, event }: EventResultsViewProps) => {
                     onPointerCancel={handleClubDragEnd}
                     className={cn(
                       'group flex w-full touch-none cursor-row-resize select-none flex-col items-center pb-1 pt-1',
-                      isClubSheetDragging && 'cursor-grabbing',
+                      isClubSheetDragging && 'cursor-grabbing'
                     )}
                   >
                     <span className="h-1.5 w-12 rounded-full bg-muted-foreground/30 transition-colors group-hover:bg-muted-foreground/50" />
@@ -708,54 +740,11 @@ const CategoryResultsView = ({
     onCompetitorsCountChange?.(competitors.length);
   }, [competitors.length, onCompetitorsCountChange]);
 
-  const getActiveTimeState = (
-    startTime?: string
-  ): { value: string; className: string } => {
-    if (!startTime) {
-      return { value: '-', className: 'text-muted-foreground' };
-    }
-
-    try {
-      const start = new Date(startTime).getTime();
-
-      if (isNaN(start)) {
-        return { value: '-', className: 'text-muted-foreground' };
-      }
-
-      const elapsedSeconds = Math.floor((currentTime - start) / 1000);
-
-      if (elapsedSeconds < 0) {
-        const secondsUntilStart = Math.abs(elapsedSeconds);
-        const className =
-          secondsUntilStart <= 5
-            ? 'animate-pulse text-orange-600 dark:text-orange-400'
-            : 'text-muted-foreground';
-
-        return {
-          value: `- ${formatSecondsToTime(secondsUntilStart)}`,
-          className,
-        };
-      }
-
-      const className =
-        elapsedSeconds <= 5
-          ? 'animate-pulse text-green-600 dark:text-green-400'
-          : 'text-muted-foreground';
-
-      return {
-        value: formatSecondsToTime(elapsedSeconds),
-        className,
-      };
-    } catch {
-      return { value: '-', className: 'text-muted-foreground' };
-    }
-  };
-
   const getCategoryTimeState = (
     competitor: ProcessedCompetitor
   ): { value: string; className: string; hideOnDesktop?: boolean } => {
     if (competitor.status === 'Active') {
-      return getActiveTimeState(competitor.startTime);
+      return getActiveTimeState(competitor.startTime, currentTime);
     }
 
     if (competitor.status === 'Inactive') {
@@ -1255,9 +1244,7 @@ const ClubResultsView = ({
             // alphabetically within each status group instead of by time.
             if (
               isUnorderedResultListMode(
-                getCompetitorResultListMode(
-                  a.competitor as CompetitorWithClass
-                )
+                getCompetitorResultListMode(a.competitor as CompetitorWithClass)
               )
             ) {
               return compareByStatusPriorityThenName(
@@ -1616,191 +1603,841 @@ const ClubResultsView = ({
   );
 };
 
+// ─── Relay overview ──────────────────────────────────────────────────────────
+
+interface TeamLegResult {
+  legNumber: number;
+  runner: Competitor;
+  legTime?: number;
+  legRank?: number;
+  legLoss?: number;
+  cumulativeTime?: number;
+  cumulativeRank?: number;
+  cumulativeLoss?: number;
+  positionChange?: number;
+}
+
+interface TeamResult {
+  teamId: number;
+  teamName: string;
+  club: string;
+  finalRank?: number;
+  totalTime?: number;
+  timeDiff?: number;
+  legs: TeamLegResult[];
+}
+
+const computeRelayOverall = (
+  allCompetitors: Competitor[],
+  maxLeg: number
+): TeamResult[] => {
+  if (maxLeg === 0 || allCompetitors.length === 0) return [];
+
+  const teamMap = new Map<number, Competitor[]>();
+  for (const c of allCompetitors) {
+    if (c.teamId == null) continue;
+    if (!teamMap.has(c.teamId)) teamMap.set(c.teamId, []);
+    teamMap.get(c.teamId)!.push(c);
+  }
+  if (teamMap.size === 0) return [];
+
+  const legBestTimes = new Map<number, number>();
+  const legRankById = new Map<string, number>();
+  for (let leg = 1; leg <= maxLeg; leg++) {
+    const legRunners = allCompetitors
+      .filter(c => c.leg === leg && c.status === 'OK' && c.time != null)
+      .sort((a, b) => (a.time ?? 0) - (b.time ?? 0));
+    const firstTime = legRunners[0]?.time;
+    if (firstTime != null) legBestTimes.set(leg, firstTime);
+    let pos = 1;
+    for (let i = 0; i < legRunners.length; i++) {
+      const cur = legRunners[i]!;
+      const prev = i > 0 ? legRunners[i - 1] : undefined;
+      const prevRank = prev ? (legRankById.get(prev.id) ?? pos) : undefined;
+      const rank =
+        prev && cur.time === prev.time && prevRank != null ? prevRank : pos;
+      legRankById.set(cur.id, rank);
+      pos++;
+    }
+  }
+
+  const teamCumulByLeg = new Map<number, Map<number, number>>();
+  for (const [teamId, runners] of teamMap) {
+    const byLeg = new Map<number, Competitor>();
+    for (const r of runners) {
+      if (r.leg != null) byLeg.set(r.leg, r);
+    }
+    const cumul = new Map<number, number>();
+    let total = 0;
+    let broken = false;
+    for (let leg = 1; leg <= maxLeg; leg++) {
+      if (broken) continue;
+      const runner = byLeg.get(leg);
+      if (!runner || runner.status !== 'OK' || runner.time == null) {
+        broken = true;
+        continue;
+      }
+      total += runner.time;
+      cumul.set(leg, total);
+    }
+    teamCumulByLeg.set(teamId, cumul);
+  }
+
+  const cumulRankKey = (tid: number, leg: number) => `${tid}_${leg}`;
+  const cumulRankMap = new Map<string, number>();
+  const legLeaderCumulTime = new Map<number, number>();
+  for (let leg = 1; leg <= maxLeg; leg++) {
+    const entries: { teamId: number; time: number }[] = [];
+    for (const [teamId, cumul] of teamCumulByLeg) {
+      const t = cumul.get(leg);
+      if (t != null) entries.push({ teamId, time: t });
+    }
+    entries.sort((a, b) => a.time - b.time);
+    const firstEntry = entries[0];
+    if (firstEntry != null) legLeaderCumulTime.set(leg, firstEntry.time);
+    let pos = 1;
+    for (let i = 0; i < entries.length; i++) {
+      const cur = entries[i]!;
+      const prev = i > 0 ? entries[i - 1] : undefined;
+      const prevRank = prev
+        ? (cumulRankMap.get(cumulRankKey(prev.teamId, leg)) ?? pos)
+        : undefined;
+      const rank =
+        prev && cur.time === prev.time && prevRank != null ? prevRank : pos;
+      cumulRankMap.set(cumulRankKey(cur.teamId, leg), rank);
+      pos++;
+    }
+  }
+
+  const results: TeamResult[] = [];
+  for (const [teamId, runners] of teamMap) {
+    const byLeg = new Map<number, Competitor>();
+    for (const r of runners) {
+      if (r.leg != null) byLeg.set(r.leg, r);
+    }
+    const cumul = teamCumulByLeg.get(teamId) ?? new Map<number, number>();
+    const totalTime = cumul.get(maxLeg);
+    const finalRank = cumulRankMap.get(cumulRankKey(teamId, maxLeg));
+    const leaderFinalTime = legLeaderCumulTime.get(maxLeg);
+    const timeDiff =
+      totalTime != null &&
+      leaderFinalTime != null &&
+      totalTime > leaderFinalTime
+        ? totalTime - leaderFinalTime
+        : undefined;
+
+    const sortedRunners = [...byLeg.entries()]
+      .sort(([a], [b]) => a - b)
+      .map(([, r]) => r);
+    const firstRunner = sortedRunners[0] ?? runners[0]!;
+    const teamName = firstRunner.team?.name ?? String(teamId);
+    const club = firstRunner.organisation ?? '';
+
+    const legs: TeamLegResult[] = [];
+    for (let leg = 1; leg <= maxLeg; leg++) {
+      const runner = byLeg.get(leg);
+      if (!runner) continue;
+      const legTime =
+        runner.status === 'OK' ? (runner.time ?? undefined) : undefined;
+      const legBest = legBestTimes.get(leg);
+      const legRank = legRankById.get(runner.id);
+      const legLoss =
+        legTime != null && legBest != null && legTime > legBest
+          ? legTime - legBest
+          : undefined;
+      const cumulTime = cumul.get(leg);
+      const cumulRank = cumulRankMap.get(cumulRankKey(teamId, leg));
+      const prevCumulRank =
+        leg > 1 ? cumulRankMap.get(cumulRankKey(teamId, leg - 1)) : undefined;
+      const positionChange =
+        cumulRank != null && prevCumulRank != null
+          ? cumulRank - prevCumulRank
+          : undefined;
+      const leaderCumul = legLeaderCumulTime.get(leg);
+      const cumulativeLoss =
+        cumulTime != null && leaderCumul != null && cumulTime > leaderCumul
+          ? cumulTime - leaderCumul
+          : undefined;
+
+      const legResult: TeamLegResult = { legNumber: leg, runner };
+      if (legTime !== undefined) legResult.legTime = legTime;
+      if (legRank !== undefined) legResult.legRank = legRank;
+      if (legLoss !== undefined) legResult.legLoss = legLoss;
+      if (cumulTime !== undefined) legResult.cumulativeTime = cumulTime;
+      if (cumulRank !== undefined) legResult.cumulativeRank = cumulRank;
+      if (positionChange !== undefined)
+        legResult.positionChange = positionChange;
+      if (cumulativeLoss !== undefined)
+        legResult.cumulativeLoss = cumulativeLoss;
+      legs.push(legResult);
+    }
+
+    const teamResult: TeamResult = { teamId, teamName, club, legs };
+    if (finalRank !== undefined) teamResult.finalRank = finalRank;
+    if (totalTime !== undefined) teamResult.totalTime = totalTime;
+    if (timeDiff !== undefined) teamResult.timeDiff = timeDiff;
+    results.push(teamResult);
+  }
+
+  results.sort((a, b) => {
+    if (a.finalRank != null && b.finalRank != null)
+      return a.finalRank - b.finalRank;
+    if (a.finalRank != null) return -1;
+    if (b.finalRank != null) return 1;
+    return (
+      b.legs.filter(l => l.cumulativeTime != null).length -
+      a.legs.filter(l => l.cumulativeTime != null).length
+    );
+  });
+
+  return results;
+};
+
+const relayStatusEmoji: Record<string, string> = {
+  Active: '🏃',
+  DidNotFinish: '🏳️',
+  DidNotStart: '🚷',
+  Disqualified: '🟥',
+  Finished: '🏁',
+  Inactive: '🛏️',
+  MissingPunch: '🙈',
+  NotCompeting: '🦄',
+  OverTime: '⌛',
+};
+
+const relayStatusTooltip: Record<string, string> = {
+  Active: 'Giving it their all right now',
+  DidNotFinish: 'Did Not Finish',
+  DidNotStart: 'Did Not Start',
+  Disqualified: 'Disqualified',
+  Finished: 'Waiting for readout',
+  Inactive: 'Waiting for start time',
+  MissingPunch: 'Missing Punch',
+  NotCompeting: 'Not competing',
+  OverTime: 'Over Time',
+};
+
+const PositionChange: React.FC<{ change: number }> = ({ change }) => {
+  if (change === 0) {
+    return (
+      <span className="text-muted-foreground text-[10px] font-bold leading-none">
+        —
+      </span>
+    );
+  }
+  if (change < 0) {
+    return (
+      <span className="text-green-500 text-[10px] font-bold leading-none">
+        ▲{Math.abs(change)}
+      </span>
+    );
+  }
+  return (
+    <span className="text-red-500 text-[10px] font-bold leading-none">
+      ▼{change}
+    </span>
+  );
+};
+
+const RelayOverallView: React.FC<{ teams: TeamResult[] }> = ({ teams }) => {
+  if (teams.length === 0) return null;
+
+  return (
+    <div className="border border-border rounded-lg overflow-hidden">
+      <div className={mobileResultsTableClassName}>
+        <Table>
+          <TableHeader>
+            <TableRow className="bg-muted/50">
+              <TableHead className="h-8 px-2 text-xs">#</TableHead>
+              <TableHead className="h-8 px-2 text-xs">Name</TableHead>
+              <TableHead className="h-8 px-2 text-xs hidden lg:table-cell">
+                Club
+              </TableHead>
+              <TableHead className="h-8 px-2 text-right text-xs">Leg</TableHead>
+              <TableHead className="h-8 px-2 text-right text-xs hidden sm:table-cell">
+                +Leg
+              </TableHead>
+              <TableHead className="h-8 px-2 text-right text-xs">
+                Time
+              </TableHead>
+              <TableHead className="h-8 px-2 text-right text-xs">
+                +Time
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {teams.map((team, teamIndex) => (
+              <React.Fragment key={team.teamId}>
+                <TableRow
+                  className={`border-t-2 border-border ${
+                    teamIndex % 2 === 0 ? 'bg-muted/30' : 'bg-muted/15'
+                  }`}
+                >
+                  <TableCell className="px-2 py-1.5 text-sm font-bold">
+                    {team.finalRank != null ? `${team.finalRank}.` : '–'}
+                  </TableCell>
+                  <TableCell className="px-2 py-1.5 text-sm font-bold">
+                    <div className="flex flex-col">
+                      <span>{team.teamName}</span>
+                      <span className="text-xs font-normal text-muted-foreground lg:hidden">
+                        {team.club}
+                      </span>
+                    </div>
+                  </TableCell>
+                  <TableCell className="px-2 py-1.5 text-xs text-muted-foreground hidden lg:table-cell">
+                    {team.club}
+                  </TableCell>
+                  <TableCell />
+                  <TableCell className="hidden sm:table-cell" />
+                  <TableCell className="px-2 py-1.5 text-right font-mono text-sm font-bold">
+                    {team.totalTime != null
+                      ? formatSecondsToTime(team.totalTime)
+                      : '–'}
+                  </TableCell>
+                  <TableCell className="px-2 py-1.5 text-right font-mono text-sm text-muted-foreground">
+                    {team.timeDiff != null && team.timeDiff > 0
+                      ? `+${formatSecondsToTime(team.timeDiff)}`
+                      : ''}
+                  </TableCell>
+                </TableRow>
+                {team.legs.map(leg => (
+                  <TableRow
+                    key={leg.legNumber}
+                    className={
+                      teamIndex % 2 === 0 ? 'bg-background' : 'bg-muted/5'
+                    }
+                  >
+                    <TableCell />
+                    <TableCell className="px-2 py-0.5 text-xs">
+                      <span className="text-muted-foreground mr-1">
+                        {leg.runner.registration}
+                      </span>
+                      {leg.runner.firstname} {leg.runner.lastname}
+                    </TableCell>
+                    <TableCell className="hidden lg:table-cell" />
+                    <TableCell className="px-2 py-0.5 text-right font-mono text-xs">
+                      {leg.legTime != null ? (
+                        <>
+                          {formatSecondsToTime(leg.legTime)}
+                          {leg.legRank != null && (
+                            <span className="text-muted-foreground ml-1">
+                              ({leg.legRank}.)
+                            </span>
+                          )}
+                        </>
+                      ) : (
+                        <span
+                          className="text-muted-foreground cursor-help"
+                          title={
+                            relayStatusTooltip[leg.runner.status] ??
+                            leg.runner.status
+                          }
+                        >
+                          {relayStatusEmoji[leg.runner.status] ?? '–'}
+                        </span>
+                      )}
+                    </TableCell>
+                    <TableCell className="px-2 py-0.5 text-right font-mono text-xs text-muted-foreground hidden sm:table-cell">
+                      {leg.legLoss != null
+                        ? `+${formatSecondsToTime(leg.legLoss)}`
+                        : ''}
+                    </TableCell>
+                    <TableCell className="px-2 py-0.5 text-right font-mono text-xs">
+                      {leg.cumulativeTime != null ? (
+                        <span className="inline-flex items-center justify-end gap-1">
+                          {leg.positionChange != null &&
+                            leg.positionChange !== 0 && (
+                              <PositionChange change={leg.positionChange} />
+                            )}
+                          {formatSecondsToTime(leg.cumulativeTime)}
+                          {leg.cumulativeRank != null && (
+                            <span className="text-muted-foreground">
+                              ({leg.cumulativeRank}.)
+                            </span>
+                          )}
+                        </span>
+                      ) : (
+                        '–'
+                      )}
+                    </TableCell>
+                    <TableCell className="px-2 py-0.5 text-right font-mono text-xs text-muted-foreground">
+                      {leg.cumulativeLoss != null
+                        ? `+${formatSecondsToTime(leg.cumulativeLoss)}`
+                        : ''}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </React.Fragment>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+};
+
 // Relay Results Component
+interface RelayLegCompetitor extends Competitor {
+  cumulativeTime?: number;
+  position?: number | string;
+  positionTooltip?: string;
+  loss?: number;
+}
+
+const processRelayLegCompetitors = (
+  legCompetitors: Competitor[],
+  selectedLeg: number,
+  teamTimeMap: Map<number, Map<number, number>>
+): RelayLegCompetitor[] => {
+  const getCumulativeTime = (c: Competitor): number | undefined => {
+    if (selectedLeg === 1) return c.time ?? undefined;
+    if (c.teamId == null || c.leg == null) return c.time ?? undefined;
+    const legMap = teamTimeMap.get(c.teamId);
+    if (!legMap) return undefined;
+    let total = 0;
+    for (let l = 1; l <= c.leg; l++) {
+      const t = legMap.get(l);
+      if (t == null) return undefined;
+      total += t;
+    }
+    return total;
+  };
+
+  const statusPriority: Record<string, number> = {
+    OK: 0,
+    Active: 1,
+    Finished: 2,
+    Inactive: 3,
+    NotCompeting: 4,
+    OverTime: 5,
+    Disqualified: 6,
+    MissingPunch: 7,
+    DidNotFinish: 8,
+    DidNotStart: 9,
+  };
+
+  type WithCumulative = Competitor & { cumulativeTime?: number };
+
+  const withCumulative: WithCumulative[] = legCompetitors.map(c => {
+    const entry: WithCumulative = { ...c };
+    const ct = getCumulativeTime(c);
+    if (ct !== undefined) entry.cumulativeTime = ct;
+    return entry;
+  });
+
+  withCumulative.sort((a, b) => {
+    if (a.status === 'OK' && b.status === 'OK') {
+      return (a.cumulativeTime ?? Infinity) - (b.cumulativeTime ?? Infinity);
+    }
+    if (a.status === 'OK') return -1;
+    if (b.status === 'OK') return 1;
+    const pa = statusPriority[a.status] ?? 10;
+    const pb = statusPriority[b.status] ?? 10;
+    if (pa !== pb) return pa - pb;
+    const sa = a.startTime ? new Date(a.startTime).getTime() : Infinity;
+    const sb = b.startTime ? new Date(b.startTime).getTime() : Infinity;
+    return sa - sb;
+  });
+
+  const okCompetitors = withCumulative.filter(c => c.status === 'OK');
+  const leaderTime = okCompetitors[0]?.cumulativeTime ?? null;
+
+  let position = 1;
+  const posMap = new Map<string, number>();
+  for (let i = 0; i < okCompetitors.length; i++) {
+    const cur = okCompetitors[i]!;
+    const prev = i > 0 ? okCompetitors[i - 1] : undefined;
+    const curT = cur.cumulativeTime ?? -1;
+    const prevT = prev?.cumulativeTime ?? -1;
+    const assignedPos =
+      prev && curT === prevT ? (posMap.get(prev.id) ?? position) : position;
+    posMap.set(cur.id, assignedPos);
+    position++;
+  }
+
+  const statusEmojis: Record<string, [string, string]> = {
+    Active: ['🏃', 'Giving it their all right now'],
+    DidNotFinish: ['🏳️', 'Did Not Finish'],
+    DidNotStart: ['🚷', 'Did not start'],
+    Disqualified: ['🟥', 'Disqualified'],
+    Finished: ['🏁', 'Waiting for readout'],
+    Inactive: ['🛏️', 'Waiting for start time'],
+    MissingPunch: ['🙈', 'Missing Punch'],
+    NotCompeting: ['🦄', 'Not competing'],
+    OverTime: ['⌛', 'Over Time'],
+  };
+
+  return withCumulative.map(c => {
+    const pos = posMap.get(c.id);
+    if (pos !== undefined) {
+      const loss =
+        leaderTime != null && c.cumulativeTime != null
+          ? c.cumulativeTime - leaderTime
+          : undefined;
+      const result: RelayLegCompetitor = { ...c, position: pos };
+      if (loss !== undefined && loss > 0) result.loss = loss;
+      return result;
+    }
+    const [emoji, tooltip] = statusEmojis[c.status] ?? ['❓', 'Unknown status'];
+    return {
+      ...c,
+      position: emoji,
+      positionTooltip: tooltip,
+    } as RelayLegCompetitor;
+  });
+};
+
 interface RelayResultsViewProps {
+  t: TFunction;
   event: Event;
   selectedClass: string;
   setSelectedClass: (cls: string) => void;
-  availableClasses: string[];
 }
 
 const RelayResultsView = ({
+  t,
   event,
   selectedClass,
   setSelectedClass,
-  availableClasses,
 }: RelayResultsViewProps) => {
-  const [expandedTeam, setExpandedTeam] = useState<string | null>(null);
-  const [isSheetOpen, setIsSheetOpen] = useState(false);
-  const [relayResults, setRelayResults] = useState<RelayResult[]>([]);
+  const [selectedTab, setSelectedTab] = useState<'overall' | number>('overall');
+  const [currentTime, setCurrentTime] = useState<number>(Date.now());
   const navigate = useNavigate();
 
-  const selectedClassId = event.classes?.find(
-    cls => cls.name === selectedClass
-  )?.id;
+  const currentClass = event.classes?.find(cls => cls.name === selectedClass);
+  const selectedClassId = currentClass?.id;
 
-  const { loading, data } = useSubscription<RelayResultsUpdatedResponse>(
-    RELAY_RESULTS_UPDATED,
-    {
-      variables: {
-        eventId: event.id,
-        classId: selectedClassId,
-      },
-      skip: !selectedClassId,
-    }
+  const { loading, error, data } =
+    useSubscription<CompetitorsByClassUpdatedResponse>(
+      COMPETITORS_BY_CLASS_UPDATED,
+      { variables: { classId: selectedClassId }, skip: !selectedClassId }
+    );
+
+  useEffect(() => {
+    setSelectedTab('overall');
+  }, [selectedClassId]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCurrentTime(Date.now());
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const allCompetitors = data?.competitorsByClassUpdated ?? [];
+
+  const maxLeg = useMemo(
+    () => allCompetitors.reduce((max, c) => Math.max(max, c.leg ?? 1), 0),
+    [allCompetitors]
   );
 
-  // Handler pro změnu třídy
-  const handleClassChange = (cls: string) => {
-    setSelectedClass(cls);
-    const newSearchParams = new URLSearchParams(window.location.search);
-    newSearchParams.set('class', cls);
+  const legs = useMemo(
+    () => (maxLeg > 0 ? Array.from({ length: maxLeg }, (_, i) => i + 1) : []),
+    [maxLeg]
+  );
 
+  const teamResults = useMemo(
+    () => computeRelayOverall(allCompetitors, maxLeg),
+    [allCompetitors, maxLeg]
+  );
+
+  const teamTimeMap = useMemo(() => {
+    const map = new Map<number, Map<number, number>>();
+    for (const c of allCompetitors) {
+      if (c.teamId != null && c.leg != null && c.time != null) {
+        if (!map.has(c.teamId)) map.set(c.teamId, new Map());
+        map.get(c.teamId)!.set(c.leg, c.time);
+      }
+    }
+    return map;
+  }, [allCompetitors]);
+
+  const selectedLeg = typeof selectedTab === 'number' ? selectedTab : null;
+
+  const processedLegCompetitors = useMemo(() => {
+    if (selectedLeg == null) return [];
+    const legComps = allCompetitors.filter(c => (c.leg ?? 1) === selectedLeg);
+    return processRelayLegCompetitors(legComps, selectedLeg, teamTimeMap);
+  }, [allCompetitors, selectedLeg, teamTimeMap]);
+
+  const legPositionChangeMap = useMemo(() => {
+    if (selectedLeg == null || selectedLeg <= 1)
+      return new Map<string, number>();
+    const map = new Map<string, number>();
+    for (const team of teamResults) {
+      const legResult = team.legs.find(l => l.legNumber === selectedLeg);
+      if (legResult?.positionChange != null) {
+        map.set(legResult.runner.id, legResult.positionChange);
+      }
+    }
+    return map;
+  }, [teamResults, selectedLeg]);
+
+  const hasContent =
+    selectedTab === 'overall'
+      ? teamResults.length > 0
+      : processedLegCompetitors.length > 0;
+
+  const showFirstLegStartTimes = selectedLeg === 1;
+
+  const getRelayLegTimeState = (
+    competitor: RelayLegCompetitor
+  ): { value: string; className: string; hideOnDesktop?: boolean } => {
+    if (competitor.status === 'Active') {
+      return getActiveTimeState(competitor.startTime, currentTime);
+    }
+
+    if (
+      showFirstLegStartTimes &&
+      competitor.status === 'Inactive' &&
+      competitor.startTime
+    ) {
+      return {
+        value: formatTimeToHms(competitor.startTime),
+        className: 'text-muted-foreground',
+        hideOnDesktop: true,
+      };
+    }
+
+    if (competitor.time !== undefined && competitor.time !== null) {
+      return { value: formatSecondsToTime(competitor.time), className: '' };
+    }
+
+    return { value: '-', className: 'text-muted-foreground' };
+  };
+
+  const handleClassChange = (classId: number) => {
+    const cls = event.classes?.find(c => c.id === classId);
+    if (!cls) return;
+    const newSearchParams = new URLSearchParams(window.location.search);
+    newSearchParams.set('class', cls.name);
     navigate({
       to: window.location.pathname,
       search: Object.fromEntries(newSearchParams),
       replace: true,
     });
-    setIsSheetOpen(false);
+    setSelectedClass(cls.name);
   };
 
-  useEffect(() => {
-    if (data?.relayResultsUpdated) {
-      setRelayResults(data.relayResultsUpdated);
-    }
-  }, [data]);
-
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between gap-2">
-        <h2 className="text-base font-bold">Relay Results</h2>
-
-        <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
-          <SheetTrigger asChild>
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-7 px-2 gap-1 min-w-[80px] bg-transparent"
-            >
-              <span className="text-xs font-bold">{selectedClass}</span>
-              <ChevronDown className="h-3 w-3" />
-            </Button>
-          </SheetTrigger>
-          <SheetContent side="bottom" className="h-[60vh]">
-            <SheetHeader>
-              <SheetTitle>Select Class</SheetTitle>
-              <SheetDescription className="sr-only">
-                Choose a competition class from the available options
-              </SheetDescription>
-            </SheetHeader>
-            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2 mt-6 overflow-y-auto max-h-[calc(60vh-100px)]">
-              {availableClasses.map(cls => (
+    <div className="flex flex-col h-full">
+      <div className="sticky top-0 z-10 bg-background border-b border-border pb-2 mb-2">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-1 p-0.5 bg-muted rounded-md">
+            {(() => {
+              const courseLength =
+                currentClass?.course?.length ?? currentClass?.length ?? 0;
+              return (
                 <Button
-                  key={cls}
-                  variant={selectedClass === cls ? 'default' : 'outline'}
-                  className="h-14 text-lg font-bold"
-                  onClick={() => handleClassChange(cls)}
+                  variant={selectedTab === 'overall' ? 'default' : 'ghost'}
+                  size="sm"
+                  className={
+                    courseLength > 0 ? 'h-auto py-0.5 px-2' : 'h-7 px-2'
+                  }
+                  onClick={() => setSelectedTab('overall')}
                 >
-                  {cls}
+                  <span className="flex flex-col items-center leading-none gap-0.5">
+                    <span className="text-xs font-medium">
+                      {t('Pages.Event.Results.Relay.Overall')}
+                    </span>
+                    {courseLength > 0 && (
+                      <span className="text-[9px] opacity-70 font-normal">
+                        {(courseLength / 1000).toFixed(1)} km
+                      </span>
+                    )}
+                  </span>
                 </Button>
-              ))}
-            </div>
-          </SheetContent>
-        </Sheet>
+              );
+            })()}
+            {legs.map(leg => {
+              const course = currentClass?.course;
+              const courseLength = course?.length ?? null;
+              const courseClimb = course?.climb ?? null;
+              return (
+                <Button
+                  key={leg}
+                  variant={selectedTab === leg ? 'default' : 'ghost'}
+                  size="sm"
+                  className={courseLength ? 'h-auto py-0.5 px-2' : 'h-7 px-2'}
+                  onClick={() => setSelectedTab(leg)}
+                >
+                  <span className="flex flex-col items-center leading-none gap-0.5">
+                    <span className="text-xs font-medium">
+                      {t('Pages.Event.Results.Relay.Leg', { number: leg })}
+                    </span>
+                    {courseLength != null && (
+                      <span className="text-[9px] opacity-70 font-normal">
+                        {(courseLength / 1000).toFixed(1)} km
+                        {courseClimb ? ` · ${courseClimb} m` : ''}
+                      </span>
+                    )}
+                  </span>
+                </Button>
+              );
+            })}
+          </div>
+          {event.classes && currentClass && (
+            <EventCategorySwitcher
+              classes={event.classes}
+              selectedClass={selectedClassId ?? 0}
+              onClassChange={handleClassChange}
+              currentClass={currentClass}
+            />
+          )}
+        </div>
       </div>
 
-      {loading && relayResults.length === 0 && (
+      {loading && !hasContent && (
         <div className="flex items-center justify-center py-12">
           <Loader2 className="w-6 h-6 animate-spin mr-2" />
-          <span>Loading relay results...</span>
+          <span>{t('Pages.Event.Results.Loading')}</span>
         </div>
       )}
 
-      <div className="space-y-4">
-        {relayResults.map(result => (
-          <div
-            key={result.id}
-            className="border border-border rounded-lg overflow-hidden"
-          >
-            <div
-              className="p-4 bg-muted/30 cursor-pointer hover:bg-muted/50 transition-colors"
-              onClick={() =>
-                setExpandedTeam(expandedTeam === result.id ? null : result.id)
-              }
-            >
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-4">
-                  <span className="text-2xl font-bold">
-                    {result.rank === 1 && '🥇'}
-                    {result.rank === 2 && '🥈'}
-                    {result.rank === 3 && '🥉'}
-                    {result.rank > 3 && result.rank}
-                  </span>
-                  <div>
-                    <div className="font-bold text-lg">{result.teamName}</div>
-                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                      <CountryFlag
-                        countryCode={result.countryCode}
-                        className="w-5 h-3"
-                      />
-                      <span>{result.club}</span>
-                    </div>
-                  </div>
-                </div>
-                <div className="text-right">
-                  <div className="font-mono font-bold text-lg">
-                    {result.totalTime}
-                  </div>
-                  {result.behind && (
-                    <div className="text-sm text-muted-foreground font-mono">
-                      {result.behind}
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
+      {error && (
+        <Alert
+          severity="error"
+          variant="outlined"
+          title="Error loading results"
+        >
+          {error.message}
+        </Alert>
+      )}
 
-            {expandedTeam === result.id && (
-              <div className="border-t border-border">
-                <Table>
-                  <TableHeader>
-                    <TableRow className="bg-muted/20">
-                      <TableHead className="w-16">Leg</TableHead>
-                      <TableHead>Runner</TableHead>
-                      <TableHead className="text-right">Time</TableHead>
-                      <TableHead className="text-right">Rank</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {result.legs.map(leg => (
-                      <TableRow key={leg.legNumber}>
-                        <TableCell className="font-bold">
-                          {leg.legNumber}
-                        </TableCell>
-                        <TableCell>{leg.runnerName}</TableCell>
-                        <TableCell className="text-right font-mono">
-                          {leg.time}
-                        </TableCell>
-                        <TableCell className="text-right">
-                          {leg.rank === 1 ? (
-                            <Badge variant="default" className="bg-primary">
-                              {leg.rank}
-                            </Badge>
-                          ) : (
-                            <span className="text-muted-foreground">
-                              {leg.rank}
+      {!loading && !error && !hasContent && (
+        <Alert
+          severity="info"
+          variant="outlined"
+          title={t('Pages.Event.Alert.EventDataNotAvailableTitle')}
+        >
+          {t('Pages.Event.Alert.EventDataNotAvailableMessage', {
+            view: t('Pages.Event.Alert.ViewResults'),
+          })}
+        </Alert>
+      )}
+
+      {selectedTab === 'overall' && <RelayOverallView teams={teamResults} />}
+
+      {typeof selectedTab === 'number' &&
+        processedLegCompetitors.length > 0 && (
+          <div className="border border-border rounded-lg overflow-hidden">
+            <div className={mobileResultsTableClassName}>
+              <Table>
+                <TableHeader>
+                  <TableRow className="bg-muted/50">
+                    <TableHead className="h-8 px-2 text-xs">#</TableHead>
+                    <TableHead className="h-8 px-2 text-xs">Name</TableHead>
+                    <TableHead className="h-8 px-2 text-xs hidden lg:table-cell">
+                      Club
+                    </TableHead>
+                    {showFirstLegStartTimes && (
+                      <TableHead className="h-8 px-2 text-xs text-right hidden md:table-cell">
+                        {t('Pages.Event.Results.Relay.Start')}
+                      </TableHead>
+                    )}
+                    <TableHead className="h-8 px-2 text-right text-xs">
+                      {t('Pages.Event.Results.Relay.Time')}
+                    </TableHead>
+                    {selectedLeg != null && selectedLeg > 1 && (
+                      <TableHead className="h-8 px-2 text-right text-xs hidden sm:table-cell">
+                        Cumul.
+                      </TableHead>
+                    )}
+                    <TableHead className="h-8 px-2 text-right text-xs">
+                      Diff
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {processedLegCompetitors.map((competitor, index) => {
+                    const timeState = getRelayLegTimeState(competitor);
+                    return (
+                      <motion.tr
+                        key={competitor.id}
+                        layout
+                        initial={{ opacity: 0, y: 30 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        transition={{
+                          type: 'spring',
+                          stiffness: 100,
+                          damping: 15,
+                        }}
+                        className={`h-9 ${
+                          index % 2 === 0
+                            ? 'bg-background hover:bg-muted/30'
+                            : 'bg-muted/20 hover:bg-muted/40'
+                        }`}
+                      >
+                        <TableCell
+                          className="px-2 py-1 text-sm font-bold"
+                          title={competitor.positionTooltip || ''}
+                        >
+                          <span className="inline-flex items-center gap-1">
+                            <span>
+                              {competitor.position}
+                              {typeof competitor.position === 'number' && '.'}
                             </span>
+                            {(() => {
+                              const change = legPositionChangeMap.get(
+                                competitor.id
+                              );
+                              if (change == null || change === 0) return null;
+                              return <PositionChange change={change} />;
+                            })()}
+                          </span>
+                        </TableCell>
+                        <TableCell className="px-2 py-1 text-sm font-medium">
+                          <div className="flex flex-col">
+                            <CompetitorName competitor={competitor} />
+                            <span className="mt-0.5 block truncate text-left text-xs text-muted-foreground lg:hidden">
+                              {competitor.organisation}
+                            </span>
+                          </div>
+                        </TableCell>
+                        <TableCell className="px-2 py-1 text-xs text-muted-foreground hidden lg:table-cell">
+                          {competitor.organisation}
+                        </TableCell>
+                        {showFirstLegStartTimes && (
+                          <TableCell className="px-2 py-1 text-right font-mono text-xs hidden md:table-cell">
+                            {competitor.startTime
+                              ? formatTimeToHms(competitor.startTime)
+                              : '-'}
+                          </TableCell>
+                        )}
+                        <TableCell
+                          className={`px-2 py-1 text-right font-mono text-sm ${timeState.className}`}
+                        >
+                          {timeState.hideOnDesktop ? (
+                            <>
+                              <span className="md:hidden">
+                                {timeState.value}
+                              </span>
+                              <span className="hidden md:inline">&nbsp;</span>
+                            </>
+                          ) : (
+                            timeState.value
                           )}
                         </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
-            )}
+                        {selectedLeg != null && selectedLeg > 1 && (
+                          <TableCell className="px-2 py-1 text-right font-mono text-sm hidden sm:table-cell">
+                            {competitor.cumulativeTime != null
+                              ? formatSecondsToTime(competitor.cumulativeTime)
+                              : '-'}
+                          </TableCell>
+                        )}
+                        <TableCell className="px-2 py-1 text-sm text-right font-mono font-bold">
+                          {competitor.loss && competitor.loss > 0
+                            ? `+${formatSecondsToTime(competitor.loss)}`
+                            : '-'}
+                        </TableCell>
+                      </motion.tr>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </div>
           </div>
-        ))}
-      </div>
+        )}
     </div>
   );
 };

--- a/apps/client/src/types/event.ts
+++ b/apps/client/src/types/event.ts
@@ -15,6 +15,13 @@ export type EventFilter =
   | 'popular'
   | 'nearby';
 
+export interface EventCourse {
+  id: number;
+  name: string;
+  length?: number | null;
+  climb?: number | null;
+}
+
 export interface EventClass {
   id: number;
   name: string;
@@ -23,6 +30,7 @@ export interface EventClass {
   climb?: number;
   controls?: number;
   resultListMode?: string | null;
+  course?: EventCourse | null;
 }
 
 export type EventStatusPrimary = 'DRAFT' | 'UPCOMING' | 'LIVE' | 'DONE';

--- a/apps/server/src/modules/class/class.graphql.ts
+++ b/apps/server/src/modules/class/class.graphql.ts
@@ -115,6 +115,7 @@ export const ClassRef = builder.prismaObject('Class', {
       nullable: true,
       resolve: (eventClass) => eventClass.status,
     }),
+    course: t.relation('course', { nullable: true }),
     competitors: t.relation('competitors', { nullable: true }),
     teams: t.relation('teams', { nullable: true }),
   }),

--- a/apps/server/src/modules/course/course.graphql.ts
+++ b/apps/server/src/modules/course/course.graphql.ts
@@ -17,6 +17,19 @@ import {
   type RadioCoursePoint,
 } from './course.service.js';
 
+export const CourseRef = builder.prismaObject('Course', {
+  fields: (t) => ({
+    id: t.exposeInt('id'),
+    eventId: t.exposeString('eventId'),
+    externalId: t.exposeString('externalId', { nullable: true }),
+    name: t.exposeString('name'),
+    courseFamily: t.exposeString('courseFamily', { nullable: true }),
+    length: t.exposeFloat('length', { nullable: true }),
+    climb: t.exposeFloat('climb', { nullable: true }),
+    controlsCount: t.exposeInt('controlsCount', { nullable: true }),
+  }),
+});
+
 const ControlRef = builder.objectRef<Control>('Control').implement({
   fields: (t) => ({
     id: t.exposeInt('id'),

--- a/apps/server/src/modules/upload/upload.handlers.ts
+++ b/apps/server/src/modules/upload/upload.handlers.ts
@@ -653,10 +653,13 @@ async function upsertTeam(
   return existingTeam.id;
 }
 
-async function upsertEmbeddedCourse(eventId: string, courseEl: Record<string, any>): Promise<void> {
+async function upsertEmbeddedCourse(
+  eventId: string,
+  courseEl: Record<string, any>,
+): Promise<number | null> {
   const externalId = getIofTextValue(courseEl.Id);
   const name = getIofTextValue(courseEl.Name) ?? externalId;
-  if (!name) return;
+  if (!name) return null;
 
   const courseData = {
     ...(externalId ? { externalId } : {}),
@@ -667,15 +670,13 @@ async function upsertEmbeddedCourse(eventId: string, courseEl: Record<string, an
     }),
   };
 
-  await prisma.course.upsert({
+  const course = await prisma.course.upsert({
     where: { eventId_name: { eventId, name } },
     update: courseData,
-    create: {
-      eventId,
-      name,
-      ...courseData,
-    },
+    create: { eventId, name, ...courseData },
+    select: { id: true },
   });
+  return course.id;
 }
 
 /**
@@ -715,8 +716,24 @@ async function processClassStarts(
       }
       if (classStart.StartName) startName = classStart.StartName[0];
 
+      // For relay, upsert the course once from the first leg before writing the
+      // class row. Doing it inside the concurrent TeamMemberStart loop would
+      // trigger concurrent class.update calls on the same row (MariaDB P2034).
+      let relayCourseId: number | null = null;
+      if (isRelayDiscipline(dbResponseEvent.discipline)) {
+        const firstCourseEl =
+          (classStart.TeamStart as Array<Record<string, any>> | undefined)?.[0]
+            ?.TeamMemberStart?.[0]
+            ?.Start?.[0]
+            ?.Course?.[0] ?? null;
+        if (firstCourseEl) {
+          relayCourseId = await upsertEmbeddedCourse(eventId, firstCourseEl);
+        }
+      }
+
       const additionalData = {
         startName: startName,
+        ...(relayCourseId !== null ? { courseId: relayCourseId } : {}),
         ...normalizeCourseMetrics({
           length,
           climb,
@@ -830,11 +847,6 @@ async function processClassStarts(
                   const start = [...teamMemberStart.Start].shift();
                   const leg = [...start.Leg].shift();
 
-                  const startCourse = Array.isArray(start.Course) ? start.Course[0] : null;
-                  if (startCourse) {
-                    await upsertEmbeddedCourse(eventId, startCourse);
-                  }
-
                   const { updated } = await upsertCompetitor(
                     eventId,
                     classId,
@@ -883,7 +895,26 @@ async function processClassResults(
     IOF_WRITE_CONCURRENCY,
     async (classResult: Record<string, any>) => {
       const classDetails = classResult.Class.shift();
-      const classId = await upsertClass(eventId, classDetails, dbClassLists, eventTimeZone);
+
+      let relayCourseId: number | null = null;
+      if (isRelayDiscipline(dbResponseEvent.discipline)) {
+        const firstCourseEl =
+          (classResult.TeamResult as Array<Record<string, any>> | undefined)?.[0]
+            ?.TeamMemberResult?.[0]
+            ?.Result?.[0]
+            ?.Course?.[0] ?? null;
+        if (firstCourseEl) {
+          relayCourseId = await upsertEmbeddedCourse(eventId, firstCourseEl);
+        }
+      }
+
+      const classId = await upsertClass(
+        eventId,
+        classDetails,
+        dbClassLists,
+        eventTimeZone,
+        relayCourseId !== null ? { courseId: relayCourseId } : {},
+      );
       const competitorCache = await loadCompetitorCache(classId);
       // Pre-load splits for all competitors already in the DB for this class.
       // One round-trip replaces N per-competitor findMany calls on re-uploads.
@@ -967,11 +998,6 @@ async function processClassResults(
                     if (!person || !result || !leg) {
                       console.warn('Skipping incomplete TeamMemberResult:', teamMemberResult);
                       return;
-                    }
-
-                    const resultCourse = Array.isArray(result.Course) ? result.Course[0] : null;
-                    if (resultCourse) {
-                      await upsertEmbeddedCourse(eventId, resultCourse);
                     }
 
                     const { id: competitorId, updated } = await upsertCompetitor(
@@ -1346,7 +1372,10 @@ async function handleIofXmlUpload(
               const length = getIofIntegerValue(course.Length);
               const climb = getIofIntegerValue(course.Climb);
 
-              // Per-leg course: ClassAssignment carries a Leg number and class name
+              // Per-leg course: ClassAssignment carries a Leg number and class name.
+              // Pass course metrics so the class row carries at least the last
+              // processed leg's length/climb (importCourseDataXml below sets the
+              // definitive Class.courseId linkage for full CourseData uploads).
               if (legNumber != null && assignment) {
                 const className: string =
                   (Array.isArray(assignment.ClassName) ? assignment.ClassName[0] : null) ??
@@ -1355,11 +1384,21 @@ async function handleIofXmlUpload(
                     : null) ??
                   course.Name[0];
                 const classDetails = { Name: [className], Id: [], ATTR: {} };
+                const additionalData = {
+                  ...normalizeCourseMetrics({
+                    length,
+                    climb,
+                    controlsCount: Array.isArray(course.CourseControl)
+                      ? course.CourseControl.length - 2
+                      : null,
+                  }),
+                };
                 await upsertClass(
                   eventId,
                   classDetails,
                   dbClassLists,
                   dbResponseEvent.timezone ?? 'UTC',
+                  additionalData,
                 );
                 return;
               }

--- a/apps/server/src/modules/upload/upload.handlers.ts
+++ b/apps/server/src/modules/upload/upload.handlers.ts
@@ -653,6 +653,31 @@ async function upsertTeam(
   return existingTeam.id;
 }
 
+async function upsertEmbeddedCourse(eventId: string, courseEl: Record<string, any>): Promise<void> {
+  const externalId = getIofTextValue(courseEl.Id);
+  const name = getIofTextValue(courseEl.Name) ?? externalId;
+  if (!name) return;
+
+  const courseData = {
+    ...(externalId ? { externalId } : {}),
+    ...normalizeCourseMetrics({
+      length: getIofIntegerValue(courseEl.Length),
+      climb: getIofIntegerValue(courseEl.Climb),
+      controlsCount: getIofIntegerValue(courseEl.NumberOfControls),
+    }),
+  };
+
+  await prisma.course.upsert({
+    where: { eventId_name: { eventId, name } },
+    update: courseData,
+    create: {
+      eventId,
+      name,
+      ...courseData,
+    },
+  });
+}
+
 /**
  * Processes class starts for an event.
  *
@@ -726,8 +751,7 @@ async function processClassStarts(
             Array.isArray(personStart.Person) && personStart.Person.length > 0
               ? personStart.Person[0]
               : null;
-          const givenName: string =
-            personEl?.Name?.[0]?.Given?.[0] ?? '';
+          const givenName: string = personEl?.Name?.[0]?.Given?.[0] ?? '';
           const isVacantPerson = givenName.trim().toLowerCase() === 'vacant';
           const hasPerson = personEl !== null && !isVacantPerson;
           if (hasPerson) {
@@ -743,7 +767,7 @@ async function processClassStarts(
           // of the [classId, startTime] unique key and cannot be null.
           if (!vacancyStartTime) continue;
           const bibNumber = vacantStart?.BibNumber
-            ? (parseInt(vacantStart.BibNumber[0] ?? '', 10) || null)
+            ? parseInt(vacantStart.BibNumber[0] ?? '', 10) || null
             : null;
           vacantSlots.push({ startTime: vacancyStartTime, bibNumber });
         }
@@ -805,6 +829,11 @@ async function processClassStarts(
                   const person = teamMemberStart.Person[0];
                   const start = [...teamMemberStart.Start].shift();
                   const leg = [...start.Leg].shift();
+
+                  const startCourse = Array.isArray(start.Course) ? start.Course[0] : null;
+                  if (startCourse) {
+                    await upsertEmbeddedCourse(eventId, startCourse);
+                  }
 
                   const { updated } = await upsertCompetitor(
                     eventId,
@@ -938,6 +967,11 @@ async function processClassResults(
                     if (!person || !result || !leg) {
                       console.warn('Skipping incomplete TeamMemberResult:', teamMemberResult);
                       return;
+                    }
+
+                    const resultCourse = Array.isArray(result.Course) ? result.Course[0] : null;
+                    if (resultCourse) {
+                      await upsertEmbeddedCourse(eventId, resultCourse);
                     }
 
                     const { id: competitorId, updated } = await upsertCompetitor(
@@ -1305,6 +1339,32 @@ async function handleIofXmlUpload(
           });
           await Promise.all(
             courseData.map(async (course) => {
+              const assignment = Array.isArray(course.ClassAssignment)
+                ? course.ClassAssignment[0]
+                : null;
+              const legNumber = assignment?.Leg ? getIofIntegerValue(assignment.Leg) : null;
+              const length = getIofIntegerValue(course.Length);
+              const climb = getIofIntegerValue(course.Climb);
+
+              // Per-leg course: ClassAssignment carries a Leg number and class name
+              if (legNumber != null && assignment) {
+                const className: string =
+                  (Array.isArray(assignment.ClassName) ? assignment.ClassName[0] : null) ??
+                  (Array.isArray(assignment.ClassShortName)
+                    ? assignment.ClassShortName[0]
+                    : null) ??
+                  course.Name[0];
+                const classDetails = { Name: [className], Id: [], ATTR: {} };
+                await upsertClass(
+                  eventId,
+                  classDetails,
+                  dbClassLists,
+                  dbResponseEvent.timezone ?? 'UTC',
+                );
+                return;
+              }
+
+              // Standard (non-relay) course: update the class-level length/climb
               const classDetails = {
                 Name: [course.Name[0]],
                 Id: [],
@@ -1312,8 +1372,8 @@ async function handleIofXmlUpload(
               };
               const additionalData = {
                 ...normalizeCourseMetrics({
-                  length: getIofIntegerValue(course.Length),
-                  climb: getIofIntegerValue(course.Climb),
+                  length,
+                  climb,
                   controlsCount: Array.isArray(course.CourseControl)
                     ? course.CourseControl.length - 2
                     : null,


### PR DESCRIPTION
## Summary
- Display relay/team data in the client
- Course data are not stored for all competitors at this moment, it could enable displaying forkings

## Checklist

- [x] I linked the related issue or explained why none is needed.
- [x] I ran the relevant checks for this change.
- [x] I updated documentation or changelog entries when needed.
- [x] By submitting this pull request, I agree to the terms in `CLA.md` in the
      repository root.
