### PR TITLE
fix (client): added timestamp and source info for both start list and results upload

### DIFF
--- a/apps/client/src/i18n/locales/cs/translation.json
+++ b/apps/client/src/i18n/locales/cs/translation.json
@@ -1058,6 +1058,7 @@
           "ImportState": {
             "Creator": "Tvůrce",
             "ExternalStatus": "Status",
+            "Source": "Zdroj",
             "LastSuccessfulImport": "Poslední import",
             "SuccessCount": "Úspěšných",
             "SkippedCount": "Přeskočených",

--- a/apps/client/src/i18n/locales/de/translation.json
+++ b/apps/client/src/i18n/locales/de/translation.json
@@ -1304,6 +1304,7 @@
           "ImportState": {
             "Creator": "Ersteller",
             "ExternalStatus": "Status",
+            "Source": "Quelle",
             "LastSuccessfulImport": "Letzter Import",
             "SuccessCount": "Erfolgreich",
             "SkippedCount": "Übersprungen",

--- a/apps/client/src/i18n/locales/en/translation.json
+++ b/apps/client/src/i18n/locales/en/translation.json
@@ -1056,6 +1056,7 @@
           "ImportState": {
             "Creator": "Creator",
             "ExternalStatus": "Status",
+            "Source": "Source",
             "LastSuccessfulImport": "Last import",
             "SuccessCount": "Successful",
             "SkippedCount": "Skipped",

--- a/apps/client/src/i18n/locales/es/translation.json
+++ b/apps/client/src/i18n/locales/es/translation.json
@@ -1056,6 +1056,7 @@
           "ImportState": {
             "Creator": "Creador",
             "ExternalStatus": "Estado",
+            "Source": "Fuente",
             "LastSuccessfulImport": "Última importación",
             "SuccessCount": "Exitosos",
             "SkippedCount": "Omitidos",

--- a/apps/client/src/i18n/locales/fr/translation.json
+++ b/apps/client/src/i18n/locales/fr/translation.json
@@ -428,6 +428,7 @@
           "ImportState": {
             "Creator": "Créateur",
             "ExternalStatus": "Statut",
+            "Source": "Source",
             "LastSuccessfulImport": "Dernière importation",
             "SuccessCount": "Réussis",
             "SkippedCount": "Ignorés",

--- a/apps/client/src/i18n/locales/sv/translation.json
+++ b/apps/client/src/i18n/locales/sv/translation.json
@@ -1056,6 +1056,7 @@
           "ImportState": {
             "Creator": "Skapare",
             "ExternalStatus": "Status",
+            "Source": "Källa",
             "LastSuccessfulImport": "Senaste import",
             "SuccessCount": "Lyckade",
             "SkippedCount": "Hoppade över",

--- a/apps/client/src/pages/Event/Settings/FilesSettingsTab.tsx
+++ b/apps/client/src/pages/Event/Settings/FilesSettingsTab.tsx
@@ -18,6 +18,11 @@ import { toast } from '@/utils';
 
 const IOF_XML_V3 = 'IOF XML v3';
 
+const SOURCE_LABELS: Record<string, string> = {
+  IOF_XML: 'IOF XML',
+  MEOS: 'MeOS MOP',
+};
+
 export type RadioControl = {
   id: number;
   code: string;
@@ -145,6 +150,10 @@ const ImportStateMeta = ({
     <>
       <Separator className="my-2" />
       <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+        <span>
+          {t('Pages.Event.Settings.Files.ImportState.Source')}:{' '}
+          {SOURCE_LABELS[importState.sourceType] ?? importState.sourceType}
+        </span>
         {importState.lastSuccessfulImportAt ? (
           <span>
             {t('Pages.Event.Settings.Files.ImportState.LastSuccessfulImport')}:{' '}
@@ -295,10 +304,21 @@ export const FilesSettingsTab = ({ t, eventId }: FilesSettingsTabProps) => {
 
   const importStates = importStatesData?.eventImportStates ?? [];
 
+  // MOP payloads (MOPComplete/MOPDiff) carry start times and results in one
+  // document, so a MeOS upload is the last import for both of those sections.
+  // MOP has no course data, so courses stay IOF XML only.
   const findImportState = (payloadType: string): EventImportStateEntry | null =>
-    importStates.find(
-      s => s.sourceType === 'IOF_XML' && s.payloadType === payloadType
-    ) ?? null;
+    importStates
+      .filter(
+        s =>
+          (s.sourceType === 'IOF_XML' && s.payloadType === payloadType) ||
+          (s.sourceType === 'MEOS' && payloadType !== 'CourseData')
+      )
+      .sort(
+        (a, b) =>
+          (Date.parse(b.lastSuccessfulImportAt ?? '') || 0) -
+          (Date.parse(a.lastSuccessfulImportAt ?? '') || 0)
+      )[0] ?? null;
 
   const handleUploaded = () => {
     void refetch();

--- a/apps/client/tests/pages/Event/Settings/FilesSettingsTab.test.tsx
+++ b/apps/client/tests/pages/Event/Settings/FilesSettingsTab.test.tsx
@@ -248,6 +248,51 @@ describe('FilesSettingsTab', () => {
     expect(metaRow).toHaveTextContent('42');
   });
 
+  it('shows a MeOS MOP import state on the start list and results sections, not on courses', async () => {
+    const states = [
+      {
+        sourceType: 'IOF_XML',
+        payloadType: 'StartList',
+        rawHash: 'a'.repeat(64),
+        lastSuccessfulImportAt: '2026-06-11T10:00:00.000Z',
+        successCount: 1,
+        skippedCount: 0,
+      },
+      {
+        sourceType: 'MEOS',
+        payloadType: 'MOPDiff',
+        rawHash: 'b'.repeat(64),
+        lastSuccessfulImportAt: '2026-06-11T12:00:00.000Z',
+        successCount: 7,
+        skippedCount: 2,
+      },
+    ];
+
+    render(
+      <MockedProvider
+        mocks={[
+          statusMock({ startListAvailable: true }),
+          importStatesMock(states),
+        ]}
+      >
+        <FilesSettingsTab t={t} eventId="event-1" />
+      </MockedProvider>
+    );
+
+    await screen.findByText('Pages.Event.Settings.Files.StartList');
+
+    const hashButtons = await screen.findAllByTitle(
+      'Pages.Event.Settings.Files.ImportState.CopyHash'
+    );
+    // Start list + results show the newer MOP state; courses show nothing.
+    expect(hashButtons).toHaveLength(2);
+    hashButtons.forEach(btn => {
+      expect(btn).toHaveTextContent('bbbbbbbb…');
+      expect(btn.parentElement).toHaveTextContent('MeOS MOP');
+      expect(btn.parentElement).toHaveTextContent('2026-06-11T12:00:00.000Z');
+    });
+  });
+
   it('hides import state metadata when no state exists for a section', async () => {
     render(
       <MockedProvider mocks={[statusMock(), importStatesMock()]}>


### PR DESCRIPTION
## Summary

- Display details about upload even when using `MeOS MOP`
- #97 

## Checklist

- [x] I linked the related issue or explained why none is needed.
- [x] I ran the relevant checks for this change.
- [x] I updated documentation or changelog entries when needed.
- [x] By submitting this pull request, I agree to the terms in `CLA.md` in the
      repository root.
