### PR TITLE
feat(server): handle StartMode element with namespace prefix

### DIFF
--- a/apps/client/src/pages/Event/WinnerNotifications.tsx
+++ b/apps/client/src/pages/Event/WinnerNotifications.tsx
@@ -8,6 +8,8 @@ interface Winner {
   eventId: string;
   classId: number;
   className: string;
+  /** Class-level gender config: 'M' men, 'F' women, 'B' both */
+  classSex?: 'B' | 'M' | 'F' | null;
   name: string;
 }
 
@@ -33,6 +35,7 @@ const WINNER_UPDATED = gql`
       eventId
       classId
       className
+      classSex
       name
     }
   }
@@ -96,6 +99,35 @@ const sendNotification = (winner: Winner): void => {
 };
 
 /**
+ * Resolves the winner's gender for Czech verb inflection, best signal first:
+ * 1. the class `sex` attribute (configurable per class)
+ * 2. the class name prefix (D/W = women, H/M = men)
+ * 3. the surname ending (Czech/Slovak feminine -ová/-á), for mixed classes
+ * Unknown falls back to masculine.
+ */
+export const isFemaleWinner = (winner: Winner): boolean => {
+  if (winner.classSex === 'F') return true;
+  if (winner.classSex === 'M') return false;
+
+  const className = winner.className.trim();
+  if (/^[DW]/i.test(className)) return true;
+  if (/^[HM]/i.test(className)) return false;
+
+  // Mixed/unconfigured class - name is the only remaining signal.
+  // Server sends "lastname firstname".
+  const lastname = winner.name.trim().split(/\s+/)[0] ?? '';
+  return /(ová|ova|á)$/i.test(lastname);
+};
+
+/**
+ * Builds the Czech announcement, inflected by the winner's gender.
+ */
+export const buildAnnouncement = (winner: Winner): string =>
+  `Změna pořadí v kategorii ${winner.className}, do vedení se dostal${
+    isFemaleWinner(winner) ? 'a' : ''
+  } ${winner.name}`;
+
+/**
  * Plays gong sound and speaks winner announcement
  */
 const playGongAndSpeak = (winner: Winner): void => {
@@ -112,9 +144,7 @@ const playGongAndSpeak = (winner: Winner): void => {
     .finally(() => {
       // After short delay, start voice announcement
       setTimeout(() => {
-        const message = new SpeechSynthesisUtterance(
-          `Změna pořadí v kategorii ${winner.className}, do vedení se dostal ${winner.name}`
-        );
+        const message = new SpeechSynthesisUtterance(buildAnnouncement(winner));
         message.lang = 'cs-CZ'; // Czech language setting
         message.rate = 1; // Speech rate
         message.pitch = 1; // Voice pitch

--- a/apps/client/src/pages/Event/WinnerNotifications.tsx
+++ b/apps/client/src/pages/Event/WinnerNotifications.tsx
@@ -9,7 +9,7 @@ interface Winner {
   classId: number;
   className: string;
   /** Class-level gender config: 'M' men, 'F' women, 'B' both */
-  classSex?: 'B' | 'M' | 'F' | null;
+  classSex?: 'B' | 'M' | 'F' | null | undefined;
   name: string;
 }
 

--- a/apps/client/src/pages/Event/WinnerNotifications.tsx
+++ b/apps/client/src/pages/Event/WinnerNotifications.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client';
 import { useSubscription } from '@apollo/client/react';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { getNotificationSettings } from '../../lib/notificationSettings';
 
 // Types
@@ -46,34 +46,6 @@ export const WinnerNotification: React.FC<WinnerNotificationProps> = ({
     skip: !eventId,
   });
 
-  const [isMainTab, setIsMainTab] = useState<boolean>(false);
-
-  // Handle tab storage for sound notifications
-  useEffect(() => {
-    const handleStorageChange = (event: StorageEvent) => {
-      if (event.key === 'mainTab') {
-        setIsMainTab(
-          localStorage.getItem('mainTab') === sessionStorage.getItem('myTab')
-        );
-      }
-    };
-
-    // Each tab gets a unique ID
-    sessionStorage.setItem('myTab', Date.now().toString());
-
-    // First tab that sets "mainTab" becomes the main tab
-    if (!localStorage.getItem('mainTab')) {
-      localStorage.setItem('mainTab', sessionStorage.getItem('myTab')!);
-      setIsMainTab(true);
-    }
-
-    window.addEventListener('storage', handleStorageChange);
-
-    return () => {
-      window.removeEventListener('storage', handleStorageChange);
-    };
-  }, []);
-
   // Handle winner updates
   useEffect(() => {
     if (data?.winnerUpdated) {
@@ -83,11 +55,12 @@ export const WinnerNotification: React.FC<WinnerNotificationProps> = ({
       if (settings.general.push) {
         sendNotification(data.winnerUpdated);
       }
-      if (settings.general.sound && isMainTab) {
+      // Only the visible tab announces, so background tabs don't talk over it
+      if (settings.general.sound && !document.hidden) {
         playGongAndSpeak(data.winnerUpdated);
       }
     }
-  }, [data, isMainTab]);
+  }, [data]);
 
   if (error) {
     console.error('Subscription error:', error);
@@ -131,13 +104,12 @@ const playGongAndSpeak = (winner: Winner): void => {
     return;
   }
 
-  // Play gong sound
+  // Play gong sound; announce even if autoplay blocks it
   const gongSound = new Audio('/sounds/chime.mp3');
   gongSound
     .play()
-    .then(() => {
-      console.log('🔔 Gong played');
-
+    .catch(error => console.warn('⚠️ Error playing gong:', error))
+    .finally(() => {
       // After short delay, start voice announcement
       setTimeout(() => {
         const message = new SpeechSynthesisUtterance(
@@ -147,8 +119,6 @@ const playGongAndSpeak = (winner: Winner): void => {
         message.rate = 1; // Speech rate
         message.pitch = 1; // Voice pitch
         speechSynthesis.speak(message);
-        console.log('🔊 Winner announcement played');
       }, 1000); // 1 second delay after gong
-    })
-    .catch(error => console.error('⚠️ Error playing gong:', error));
+    });
 };

--- a/apps/client/tests/pages/Event/winner-announcement.test.ts
+++ b/apps/client/tests/pages/Event/winner-announcement.test.ts
@@ -4,7 +4,7 @@ import { buildAnnouncement } from '../../../src/pages/Event/WinnerNotifications'
 const winner = (
   className: string,
   name = 'Nováková Jana',
-  classSex?: 'B' | 'M' | 'F' | null
+  classSex: 'B' | 'M' | 'F' | null = null
 ) => ({
   eventId: 'e1',
   classId: 1,

--- a/apps/client/tests/pages/Event/winner-announcement.test.ts
+++ b/apps/client/tests/pages/Event/winner-announcement.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { buildAnnouncement } from '../../../src/pages/Event/WinnerNotifications';
+
+const winner = (
+  className: string,
+  name = 'Nováková Jana',
+  classSex?: 'B' | 'M' | 'F' | null
+) => ({
+  eventId: 'e1',
+  classId: 1,
+  className,
+  classSex,
+  name,
+});
+
+const female = (text: string) => expect(text).toContain('se dostala ');
+const male = (text: string) => expect(text).toMatch(/se dostal [^a]/);
+
+describe('buildAnnouncement', () => {
+  it('prefers the configured class sex over the class name', () => {
+    female(buildAnnouncement(winner('H21', 'Novák Jan', 'F')));
+    male(buildAnnouncement(winner('D21', 'Nováková Jana', 'M')));
+  });
+
+  it.each(['D21', 'D10C', 'W21E', 'w35'])(
+    'falls back to the class name for %s',
+    className => {
+      female(buildAnnouncement(winner(className, 'Novák Jan', 'B')));
+    }
+  );
+
+  it.each(['H21', 'H35', 'M21E', 'm40'])(
+    'falls back to the class name for %s',
+    className => {
+      male(buildAnnouncement(winner(className, 'Nováková Jana', 'B')));
+    }
+  );
+
+  it.each(['Nováková Jana', 'Krátká Eva', 'Novakova Jana'])(
+    'uses the surname for mixed classes: %s',
+    name => {
+      female(buildAnnouncement(winner('OPEN', name, 'B')));
+    }
+  );
+
+  it.each(['Novák Jan', 'Svoboda Petr', 'Costa Bruno'])(
+    'stays masculine for mixed classes: %s',
+    name => {
+      male(buildAnnouncement(winner('OPEN', name, 'B')));
+    }
+  );
+
+  it('works when the server sends no class sex', () => {
+    female(buildAnnouncement(winner('D21', 'Nováková Jana', null)));
+    male(buildAnnouncement(winner('T2', 'Novák Jan', null)));
+  });
+
+  it('includes the class name', () => {
+    expect(buildAnnouncement(winner('D21'))).toContain('v kategorii D21');
+  });
+});

--- a/apps/server/src/graphql/__tests__/__snapshots__/schema.test.ts.snap
+++ b/apps/server/src/graphql/__tests__/__snapshots__/schema.test.ts.snap
@@ -1063,6 +1063,7 @@ enum UserRole {
 type WinnerNotification {
   classId: Int!
   className: String!
+  classSex: String!
   eventId: String!
   name: String!
 }

--- a/apps/server/src/modules/event/event.graphql.ts
+++ b/apps/server/src/modules/event/event.graphql.ts
@@ -42,6 +42,7 @@ const WinnerNotificationRef = builder
       eventId: t.exposeString('eventId'),
       classId: t.exposeInt('classId'),
       className: t.exposeString('className'),
+      classSex: t.exposeString('classSex'),
       name: t.exposeString('name'),
     }),
   });

--- a/apps/server/src/modules/event/event.service.ts
+++ b/apps/server/src/modules/event/event.service.ts
@@ -1,7 +1,7 @@
 import { ConflictError, DatabaseError, ValidationError } from '../../exceptions/index.js';
 import type { AppPrismaClient } from '../../db/prisma-client.js';
 import { Prisma, type Event as PrismaEvent } from '../../generated/prisma/client.js';
-import type { Origin, ProtocolType, ResultStatus } from '../../generated/prisma/enums.js';
+import type { Origin, ProtocolType, ResultStatus, Sex } from '../../generated/prisma/enums.js';
 import { WINNER_UPDATED, pubsub as defaultPubsub } from '../../lib/pubsub.js';
 import { isRelayDiscipline } from '../../utils/relay.js';
 import prisma from '../../utils/context.js';
@@ -71,6 +71,7 @@ export type WinnerNotification = {
   eventId: string;
   classId: number;
   className: string;
+  classSex: Sex;
   name: string;
 };
 

--- a/apps/server/src/modules/event/event.winner-cache.service.ts
+++ b/apps/server/src/modules/event/event.winner-cache.service.ts
@@ -10,7 +10,7 @@ export const notifyWinnerChanges = async eventId => {
       where: { class: { eventId }, time: { not: null }, status: 'OK' },
       select: {
         classId: true,
-        class: { select: { name: true } },
+        class: { select: { name: true, sex: true } },
         id: true,
         firstname: true,
         lastname: true,
@@ -42,6 +42,7 @@ export const notifyWinnerChanges = async eventId => {
         winnerChanges.push({
           classId: newWinner.classId,
           className: newWinner.class.name,
+          classSex: newWinner.class.sex,
           competitorId: newWinner.id,
           name: `${newWinner.lastname} ${newWinner.firstname}`,
         });
@@ -63,6 +64,7 @@ export const notifyWinnerChanges = async eventId => {
             eventId,
             classId: winner.classId,
             className: winner.className,
+            classSex: winner.classSex,
             name: winner.name,
           },
         });

--- a/apps/server/src/modules/upload/__tests__/upload.handlers.test.ts
+++ b/apps/server/src/modules/upload/__tests__/upload.handlers.test.ts
@@ -121,6 +121,21 @@ describe('parseClassStartExtension', () => {
     expect(result.startWindowTo).toBeNull();
   });
 
+  it('reads namespace-prefixed extension children', () => {
+    const result = parseClassStartExtension(
+      [
+        {
+          'qe:StartMode': ['WaveStart'],
+          'qe:StartWindow': [{ StartTime: ['2026-05-01T10:00:00+02:00'] }],
+        },
+      ],
+      'Europe/Prague',
+    );
+
+    expect(result.startMode).toBe('WaveStart');
+    expect(result.startWindowFrom?.toISOString()).toBe('2026-05-01T08:00:00.000Z');
+  });
+
   it('ignores an unknown StartMode value', () => {
     const result = parseClassStartExtension([{ StartMode: ['Bogus'] }], 'Europe/Prague');
 

--- a/apps/server/src/modules/upload/upload.handlers.ts
+++ b/apps/server/src/modules/upload/upload.handlers.ts
@@ -304,9 +304,21 @@ function hasOwnProperty(record: object | null | undefined, property: string): bo
   return Object.prototype.hasOwnProperty.call(record ?? {}, property);
 }
 
+/**
+ * Extensions children live in a non-IOF namespace (the IOF XSD requires it), so
+ * producers may either declare it inline (`<StartMode xmlns="...">`) or bind a
+ * prefix on the root and use it here (`<qe:StartMode>`). xml2js keeps the raw
+ * qualified name as the key, so strip the prefix to read both forms.
+ */
 function getClassStartExtensionRecord(extensions: unknown): Record<string, unknown> | null {
   const ext = Array.isArray(extensions) ? extensions[0] : extensions;
-  return ext && typeof ext === 'object' ? (ext as Record<string, unknown>) : null;
+  if (!ext || typeof ext !== 'object') return null;
+  return Object.fromEntries(
+    Object.entries(ext as Record<string, unknown>).map(([key, value]) => [
+      key.replace(/^[^:]+:/, ''),
+      value,
+    ]),
+  );
 }
 
 /**

--- a/packages/shared/src/models/event.ts
+++ b/packages/shared/src/models/event.ts
@@ -5,6 +5,7 @@ import {
   dateLikeSchema,
   eventDisciplineSchema,
   eventFilterSchema,
+  sexSchema,
   startModeSchema,
 } from './common.js';
 
@@ -84,6 +85,7 @@ export const winnerNotificationSchema = z.object({
   eventId: z.string(),
   classId: z.number().int(),
   className: z.string(),
+  classSex: sexSchema,
   name: z.string(),
 });
 


### PR DESCRIPTION
## Summary

- When working with Extensions>StartMode element iof xsd checks the file as invalid when not using not IOF namespace. Pull request adds support for using namespace prefix. 

## Checklist

- [x] I linked the related issue or explained why none is needed.
- [x] I ran the relevant checks for this change.
- [x] I updated documentation or changelog entries when needed.
- [x] By submitting this pull request, I agree to the terms in `CLA.md` in the
      repository root.
