### PR TITLE
fix(server): mop upload handles the same name (e.g. father and son) without overwriting

### DIFF
--- a/apps/server/src/modules/meos/__tests__/meos.service.test.ts
+++ b/apps/server/src/modules/meos/__tests__/meos.service.test.ts
@@ -353,6 +353,46 @@ describe('upsertMeosCompetitor', () => {
     expect(mockTx.protocol.createMany).toHaveBeenCalled();
   });
 
+  it('creates a new competitor instead of overwriting a same-named one already linked to another MOP id', async () => {
+    // Simulate a real DB row: "Jan Novák" already linked to MOP id 999.
+    // The name-fallback queries must exclude it (externalId: null filter) so
+    // the mock only returns it if that filter is missing from the where clause.
+    const linkedNamesake = existingCompetitor({
+      id: 555,
+      externalId: '999',
+      firstname: 'Jan',
+      lastname: 'Novák',
+    });
+    mockTx.competitor.findFirst.mockImplementation(async ({ where }) => {
+      if (where.externalId === '102') return null; // byExternalId lookup miss
+      const matchesName = where.firstname === 'Jan' && where.lastname === 'Novák';
+      if (!matchesName || where.externalId === null) return null;
+      return linkedNamesake;
+    });
+    mockTx.competitor.create.mockResolvedValueOnce({ id: 102, classId: 7 });
+
+    const cmp = {
+      id: 102,
+      card: 999999,
+      competing: false,
+      firstname: 'Jan',
+      lastname: 'Novák',
+      classId: 1,
+      orgId: undefined,
+      bibNumber: 27,
+      stat: 0,
+      startTenths: 0,
+      runTimeTenths: 0,
+      splits: [],
+      delete: false,
+    };
+
+    await upsertMeosCompetitor(mockTx as never, EVENT_ID, cmp, new Map(), new Map([[1, 7]]), EVENT);
+
+    expect(mockTx.competitor.update).not.toHaveBeenCalled();
+    expect(mockTx.competitor.create).toHaveBeenCalledOnce();
+  });
+
   it('skips competitor if classId not in classIdMap', async () => {
     const cmp = {
       id: 200,

--- a/apps/server/src/modules/meos/meos.service.ts
+++ b/apps/server/src/modules/meos/meos.service.ts
@@ -92,6 +92,7 @@ async function findExistingMeosCompetitor(
   const nameWhere = {
     firstname: cmp.firstname,
     lastname: cmp.lastname,
+    externalId: null,
   };
 
   const sameClassByName = await tx.competitor.findFirst({


### PR DESCRIPTION
@martintethal faced an issue when using MOP upload during `Interkompas`. The competitors with the same name (e.g. father and son in most cases) were overwritten, e.g. [H55](https://orienteerfeed.com/events/cmt9ybqjo000w08mp8wgbs6ww?tab=results&class=H55) and [H21B](https://orienteerfeed.com/events/cmt9ybqjo000w08mp8wgbs6ww?tab=results&class=H21B).

<img width="853" height="911" alt="image" src="https://github.com/user-attachments/assets/8b25bce0-a24e-496d-9de6-047dec82d3c5" />

## Summary
Extended condition.

## Checklist
- [x] I linked the related issue or explained why none is needed.
- [x] I ran the relevant checks for this change.
- [x] I updated documentation or changelog entries when needed.
- [x] By submitting this pull request, I agree to the terms in `CLA.md` in the
      repository root.
